### PR TITLE
Feature/sqs default

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+node_modules
+coverage
+docs

--- a/lib/package/sqs/compileMethodsToSqs.js
+++ b/lib/package/sqs/compileMethodsToSqs.js
@@ -74,7 +74,7 @@ module.exports = {
       },
       RequestParameters: {
         'integration.request.querystring.Action': "'SendMessage'",
-        'integration.request.querystring.MessageBody': 'method.request.body.message'
+        'integration.request.querystring.MessageBody': 'method.request.body'
       },
       RequestTemplates: { 'application/json': '{statusCode:200}' }
     }

--- a/lib/package/sqs/compileMethodsToSqs.test.js
+++ b/lib/package/sqs/compileMethodsToSqs.test.js
@@ -76,7 +76,7 @@ describe('#compileIamRoleToSqs()', () => {
             },
             RequestParameters: {
               'integration.request.querystring.Action': "'SendMessage'",
-              'integration.request.querystring.MessageBody': 'method.request.body.message'
+              'integration.request.querystring.MessageBody': 'method.request.body'
             },
             RequestTemplates: { 'application/json': '{statusCode:200}' },
             IntegrationResponses: [
@@ -168,7 +168,7 @@ describe('#compileIamRoleToSqs()', () => {
             },
             RequestParameters: {
               'integration.request.querystring.Action': "'SendMessage'",
-              'integration.request.querystring.MessageBody': 'method.request.body.message'
+              'integration.request.querystring.MessageBody': 'method.request.body'
             },
             RequestTemplates: { 'application/json': '{statusCode:200}' },
             IntegrationResponses: [


### PR DESCRIPTION
Closes #12 

As discussed in #12 let's change the default mapping for SQS to use `method.request.body` instead of `method.request.body.message`.