### PR TITLE
Feature: add support for adding authorization

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.formatOnSave": true
+}

--- a/README.md
+++ b/README.md
@@ -2,16 +2,19 @@
 [![Build Status](https://travis-ci.org/horike37/serverless-apigateway-service-proxy.svg?branch=master)](https://travis-ci.org/horike37/serverless-apigateway-service-proxy) [![npm version](https://badge.fury.io/js/serverless-apigateway-service-proxy.svg)](https://badge.fury.io/js/serverless-apigateway-service-proxy) [![Coverage Status](https://coveralls.io/repos/github/horike37/serverless-apigateway-service-proxy/badge.svg?branch=master)](https://coveralls.io/github/horike37/serverless-apigateway-service-proxy?branch=master) [![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE)
 
 # Serverless APIGateway Service Proxy(BETA)
+
 This Serverless Framewrok plugin supports the AWS service proxy integration feature of API Gateway. You can directly connect API Gateway to AWS services without Lambda.
 
 ## Install
+
 Run `servelress plugin install` in your Serverless project.
 
-```
-$ serverless plugin install -n serverless-apigateway-service-proxy
+```bash
+serverless plugin install -n serverless-apigateway-service-proxy
 ```
 
 ## Supported AWS services
+
 Here is a services list which this plugin supports for now. But will expand to other services in the feature.
 Please pull request if you are intersted in it.
 
@@ -19,10 +22,13 @@ Please pull request if you are intersted in it.
 - SQS
 
 ## How to use
+
 Define settings of the AWS services you want to integrate under `custom > apiGatewayServiceProxies` and run `serverless deploy`.
 
 ### Kinesis
+
 Sample syntax for Kinesis proxy in serverless.yml.
+
 ```yaml
 custom:
   apiGatewayServiceProxies:
@@ -41,34 +47,38 @@ resources:
 ```
 
 Sample request after deploying.
-```
+
+```bash
 curl -XPOST https://xxxxxxx.execute-api.us-east-1.amazonaws.com/dev/kinesis -d '{"Data": "some data","PartitionKey": "some key"}'  -H 'Content-Type:application/json'
 ```
 
 ### SQS
 
 Sample syntax for SQS proxy in serverless.yml.
+
 ```yaml
 custom:
   apiGatewayServiceProxies:
     - sqs:
         path: /sqs
         method: post
-        queueName: {"Fn::GetAtt":[ "SQSQueue", "QueueName" ]}
+        queueName: { 'Fn::GetAtt': ['SQSQueue', 'QueueName'] }
         cors: true
 
 resources:
   Resources:
     SQSQueue:
-      Type: "AWS::SQS::Queue"
+      Type: 'AWS::SQS::Queue'
 ```
 
 Sample request after deploying.
-```
+
+```bash
 curl -XPOST https://xxxxxx.execute-api.us-east-1.amazonaws.com/dev/sqs -d '{"message": "testtest"}' -H 'Content-Type:application/json'
 ```
 
 ## Common API Gateway features
+
 ### Enabling CORS
 
 To set CORS configurations for your HTTP endpoints, simply modify your event configurations as follows:
@@ -142,8 +152,40 @@ custom:
           allowCredentials: false
           cacheControl: 'max-age=600, s-maxage=600, proxy-revalidate' # Caches on browser and proxy for 10 minutes and doesnt allow proxy to serve out of date content
 ```
+
+### Adding Authorization
+
+You can pass in any supported authorization type:
+
+```yml
+custom:
+  apiGatewayServiceProxies:
+    - sqs:
+        path: /sqs
+        method: post
+        queueName: { 'Fn::GetAtt': ['SQSQueue', 'QueueName'] }
+        cors: true
+
+        # optional - defaults to 'NONE'
+        authorizationType: 'AWS_IAM' # can be one of ['NONE', 'AWS_IAM', 'CUSTOM', 'COGNITO_USER_POOLS']
+
+        # when using 'CUSTOM' authorization type, one should specify authorizerId
+        # authorizerId: { Ref: 'AuthorizerLogicalId' }
+        # when using 'COGNITO_USER_POOLS' authorization type, one can specify a list of authorization scopes
+        # authorizationScopes: ['scope1','scope2']
+
+resources:
+  Resources:
+    SQSQueue:
+      Type: 'AWS::SQS::Queue'
+```
+
+Source: [AWS::ApiGateway::Method docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-method.html#cfn-apigateway-method-authorizationtype)
+
 ## Specific features
+
 ### Kinesis
+
 #### Customizing request body mapping templates
 
 If you'd like to add content types or customize the default templates, you can do so by including your custom [API Gateway request mapping template](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html) in `serverless.yml` like so:
@@ -170,4 +212,5 @@ custom:
                 - MyStreamArn:
                     Fn::GetAtt: [MyStream, Arn]
 ```
+
 Source: [How to connect SNS to Kinesis for cross-account delivery via API Gateway](https://theburningmonk.com/2019/07/how-to-connect-sns-to-kinesis-for-cross-account-delivery-via-api-gateway/)

--- a/lib/apiGateway/validate.js
+++ b/lib/apiGateway/validate.js
@@ -14,6 +14,7 @@ module.exports = {
         const http = serviceProxy[serviceName]
         http.path = await this.getProxyPath(serviceProxy[serviceName], serviceName)
         http.method = await this.getProxyMethod(serviceProxy[serviceName], serviceName)
+        http.auth = await this.getAuth(serviceProxy[serviceName], serviceName)
 
         if (serviceProxy[serviceName].cors) {
           http.cors = await this.getCors(serviceProxy[serviceName])
@@ -59,7 +60,7 @@ module.exports = {
   },
 
   async getProxyPath(proxy, serviceName) {
-    if (proxy.path && typeof proxy.path === 'string') {
+    if (proxy.path && _.isString(proxy.path)) {
       return proxy.path.replace(/^\//, '').replace(/\/$/, '')
     }
 
@@ -71,7 +72,7 @@ module.exports = {
   },
 
   async getProxyMethod(proxy, serviceName) {
-    if (proxy.method && typeof proxy.method === 'string') {
+    if (proxy.method && _.isString(proxy.method)) {
       const method = proxy.method.toLowerCase()
 
       const allowedMethods = ['get', 'post', 'put', 'patch', 'options', 'head', 'delete', 'any']
@@ -154,5 +155,60 @@ module.exports = {
     }
 
     return cors
+  },
+
+  async getAuth(proxy, serviceName) {
+    const auth = {
+      authorizationType: 'NONE'
+    }
+
+    if (!_.isUndefined(proxy.authorizationType)) {
+      if (_.isString(proxy.authorizationType)) {
+        const allowedTypes = ['NONE', 'AWS_IAM', 'CUSTOM', 'COGNITO_USER_POOLS']
+        if (allowedTypes.indexOf(proxy.authorizationType) === NOT_FOUND) {
+          const errorMessage = [
+            `Invalid APIG authorization type "${proxy.authorizationType}" in AWS service proxy.`,
+            ` AWS supported types are: ${allowedTypes.join(', ')}.`
+          ].join('')
+          return BbPromise.reject(new this.serverless.classes.Error(errorMessage))
+        }
+
+        auth.authorizationType = proxy.authorizationType
+      } else {
+        return BbPromise.reject(
+          new this.serverless.classes.Error(
+            `Invalid "authorizationType" property in ${serviceName} proxy`
+          )
+        )
+      }
+    }
+
+    if (!_.isUndefined(proxy.authorizerId)) {
+      if (auth.authorizationType !== 'CUSTOM') {
+        const errorMessage = `Expecting 'CUSTOM' authorization type when 'authorizerId' is set in service ${serviceName}`
+        return BbPromise.reject(new this.serverless.classes.Error(errorMessage))
+      }
+
+      auth.authorizerId = proxy.authorizerId
+    }
+
+    if (!_.isUndefined(proxy.authorizationScopes)) {
+      if (_.isArray(proxy.authorizationScopes)) {
+        if (auth.authorizationType !== 'COGNITO_USER_POOLS') {
+          const errorMessage = `Expecting 'COGNITO_USER_POOLS' authorization type when 'authorizationScopes' is set in service ${serviceName}`
+          return BbPromise.reject(new this.serverless.classes.Error(errorMessage))
+        }
+
+        auth.authorizationScopes = proxy.authorizationScopes
+      } else {
+        return BbPromise.reject(
+          new this.serverless.classes.Error(
+            `Invalid "authorizationScopes" property in ${serviceName} proxy`
+          )
+        )
+      }
+    }
+
+    return auth
   }
 }

--- a/lib/apiGateway/validate.test.js
+++ b/lib/apiGateway/validate.test.js
@@ -145,6 +145,9 @@ describe('#validateServiceProxies()', () => {
               serviceName: 'kinesis',
               http: {
                 path: 'kinesis',
+                auth: {
+                  authorizationType: 'NONE'
+                },
                 method: 'post',
                 cors: {
                   origins: ['*'],
@@ -231,6 +234,9 @@ describe('#validateServiceProxies()', () => {
               http: {
                 path: 'kinesis',
                 method: 'post',
+                auth: {
+                  authorizationType: 'NONE'
+                },
                 cors: {
                   headers: ['X-Foo-Bar'],
                   origins: ['acme.com'],
@@ -346,7 +352,7 @@ describe('#validateServiceProxies()', () => {
     )
   })
 
-  it('should handle expicit methods', async () => {
+  it('should handle explicit methods', async () => {
     serverlessApigatewayServiceProxy.serverless.service.custom = {
       apiGatewayServiceProxies: [
         {
@@ -364,6 +370,165 @@ describe('#validateServiceProxies()', () => {
     await expect(serverlessApigatewayServiceProxy.validateServiceProxies()).to.be.fulfilled.then(
       (json) => {
         expect(json.events[0].http.cors.methods).to.deep.equal(['POST', 'OPTIONS'])
+      }
+    )
+  })
+
+  it('should validate the "authorizationType" property', async () => {
+    serverlessApigatewayServiceProxy.serverless.service.custom = {
+      apiGatewayServiceProxies: [
+        {
+          kinesis: {
+            path: '/kinesis',
+            authorizationType: [],
+            method: 'post'
+          }
+        }
+      ]
+    }
+
+    await expect(serverlessApigatewayServiceProxy.validateServiceProxies()).to.be.rejectedWith(
+      'Invalid "authorizationType" property in kinesis proxy'
+    )
+  })
+
+  it('should validate the "authorizationType" property if set to unsupported type', async () => {
+    serverlessApigatewayServiceProxy.serverless.service.custom = {
+      apiGatewayServiceProxies: [
+        {
+          kinesis: {
+            path: '/kinesis',
+            authorizationType: 'AUTH_TYPE',
+            method: 'post'
+          }
+        }
+      ]
+    }
+
+    await expect(serverlessApigatewayServiceProxy.validateServiceProxies()).to.be.rejectedWith(
+      'Invalid APIG authorization type "AUTH_TYPE" in AWS service proxy. AWS supported types are: NONE, AWS_IAM, CUSTOM, COGNITO_USER_POOLS.'
+    )
+  })
+
+  it('should validate "authorizationType" is set to "CUSTOM" when the "authorizerId" property is set', async () => {
+    serverlessApigatewayServiceProxy.serverless.service.custom = {
+      apiGatewayServiceProxies: [
+        {
+          kinesis: {
+            path: '/kinesis',
+            authorizationType: 'NONE',
+            authorizerId: { Ref: 'SomeAuthorizerId' },
+            method: 'post'
+          }
+        }
+      ]
+    }
+
+    await expect(serverlessApigatewayServiceProxy.validateServiceProxies()).to.be.rejectedWith(
+      "Expecting 'CUSTOM' authorization type when 'authorizerId' is set in service kinesis"
+    )
+  })
+
+  it('should validate the "authorizationScopes" property', async () => {
+    serverlessApigatewayServiceProxy.serverless.service.custom = {
+      apiGatewayServiceProxies: [
+        {
+          kinesis: {
+            path: '/kinesis',
+            authorizationScopes: '',
+            method: 'post'
+          }
+        }
+      ]
+    }
+
+    await expect(serverlessApigatewayServiceProxy.validateServiceProxies()).to.be.rejectedWith(
+      'Invalid "authorizationScopes" property in kinesis proxy'
+    )
+  })
+
+  it('should validate "authorizationType" is set to "COGNITO_USER_POOLS" when the "authorizationScopes" property is set', async () => {
+    serverlessApigatewayServiceProxy.serverless.service.custom = {
+      apiGatewayServiceProxies: [
+        {
+          kinesis: {
+            path: '/kinesis',
+            authorizationType: 'NONE',
+            authorizationScopes: ['editor', 'owner'],
+            method: 'post'
+          }
+        }
+      ]
+    }
+
+    await expect(serverlessApigatewayServiceProxy.validateServiceProxies()).to.be.rejectedWith(
+      "Expecting 'COGNITO_USER_POOLS' authorization type when 'authorizationScopes' is set in service kinesis"
+    )
+  })
+
+  it('should use "NONE" authorization type when not setting auth properties', async () => {
+    serverlessApigatewayServiceProxy.serverless.service.custom = {
+      apiGatewayServiceProxies: [
+        {
+          kinesis: {
+            path: '/kinesis',
+            method: 'post'
+          }
+        }
+      ]
+    }
+
+    await expect(serverlessApigatewayServiceProxy.validateServiceProxies()).to.be.fulfilled.then(
+      (json) => {
+        expect(json.events[0].http.auth).to.deep.equal({ authorizationType: 'NONE' })
+      }
+    )
+  })
+
+  it('should handle "CUSTOM" authorizationType', async () => {
+    serverlessApigatewayServiceProxy.serverless.service.custom = {
+      apiGatewayServiceProxies: [
+        {
+          kinesis: {
+            path: '/kinesis',
+            authorizationType: 'CUSTOM',
+            authorizerId: { Ref: 'SomeAuthorizerId' },
+            method: 'post'
+          }
+        }
+      ]
+    }
+
+    await expect(serverlessApigatewayServiceProxy.validateServiceProxies()).to.be.fulfilled.then(
+      (json) => {
+        expect(json.events[0].http.auth).to.deep.equal({
+          authorizationType: 'CUSTOM',
+          authorizerId: { Ref: 'SomeAuthorizerId' }
+        })
+      }
+    )
+  })
+
+  it('should handle "COGNITO_USER_POOLS" authorizationType', async () => {
+    serverlessApigatewayServiceProxy.serverless.service.custom = {
+      apiGatewayServiceProxies: [
+        {
+          kinesis: {
+            path: '/kinesis',
+            authorizationType: 'COGNITO_USER_POOLS',
+            authorizationScopes: ['editor', 'owner'],
+            method: 'post'
+          }
+        }
+      ]
+    }
+
+    await expect(serverlessApigatewayServiceProxy.validateServiceProxies()).to.be.fulfilled.then(
+      (json) => {
+        expect(json.events[0].http.auth).to.deep.equal({
+          authorizationType: 'COGNITO_USER_POOLS',
+          authorizationScopes: ['editor', 'owner']
+        })
       }
     )
   })

--- a/lib/package/kinesis/compileMethodsToKinesis.js
+++ b/lib/package/kinesis/compileMethodsToKinesis.js
@@ -15,7 +15,9 @@ module.exports = {
           Properties: {
             HttpMethod: event.http.method.toUpperCase(),
             RequestParameters: {},
-            AuthorizationType: 'NONE',
+            AuthorizationType: event.http.auth.authorizationType,
+            AuthorizationScopes: event.http.auth.authorizationScopes,
+            AuthorizerId: event.http.auth.authorizerId,
             ApiKeyRequired: Boolean(event.http.private),
             ResourceId: resourceId,
             RestApiId: this.provider.getApiGatewayRestApiId()

--- a/lib/package/kinesis/compileMethodsToKinesis.test.js
+++ b/lib/package/kinesis/compileMethodsToKinesis.test.js
@@ -35,7 +35,10 @@ describe('#compileMethodsToKinesis()', () => {
           http: {
             streamName: 'myStream',
             path: 'kinesis',
-            method: 'post'
+            method: 'post',
+            auth: {
+              authorizationType: 'NONE'
+            }
           }
         }
       ]
@@ -57,6 +60,8 @@ describe('#compileMethodsToKinesis()', () => {
           HttpMethod: 'POST',
           RequestParameters: {},
           AuthorizationType: 'NONE',
+          AuthorizationScopes: undefined,
+          AuthorizerId: undefined,
           ApiKeyRequired: false,
           ResourceId: { Ref: 'ApiGatewayResourceKinesis' },
           RestApiId: { Ref: 'ApiGatewayRestApi' },
@@ -134,6 +139,9 @@ describe('#compileMethodsToKinesis()', () => {
             streamName: 'myStream',
             path: 'kinesis',
             method: 'post',
+            auth: {
+              authorizationType: 'NONE'
+            },
             cors: {
               origins: ['*'],
               origin: '*',
@@ -169,6 +177,8 @@ describe('#compileMethodsToKinesis()', () => {
           HttpMethod: 'POST',
           RequestParameters: {},
           AuthorizationType: 'NONE',
+          AuthorizerId: undefined,
+          AuthorizationScopes: undefined,
           ApiKeyRequired: false,
           ResourceId: { Ref: 'ApiGatewayResourceKinesis' },
           RestApiId: { Ref: 'ApiGatewayRestApi' },
@@ -253,6 +263,9 @@ describe('#compileMethodsToKinesis()', () => {
         template: {
           'application/x-www-form-urlencoded': 'custom template'
         }
+      },
+      auth: {
+        authorizationType: 'NONE'
       }
     }
 
@@ -284,6 +297,9 @@ describe('#compileMethodsToKinesis()', () => {
         template: {
           'application/json': 'custom template'
         }
+      },
+      auth: {
+        authorizationType: 'NONE'
       }
     }
     const resource = await serverlessApigatewayServiceProxy.getKinesisMethodIntegration(
@@ -302,6 +318,9 @@ describe('#compileMethodsToKinesis()', () => {
         template: {
           'application/json': 'custom template'
         }
+      },
+      auth: {
+        authorizationType: 'NONE'
       }
     }
     const resource = await serverlessApigatewayServiceProxy.getKinesisMethodIntegration(
@@ -333,6 +352,9 @@ describe('#compileMethodsToKinesis()', () => {
         template: {
           'application/x-www-form-urlencoded': 'custom template'
         }
+      },
+      auth: {
+        authorizationType: 'NONE'
       }
     }
     const resource = await serverlessApigatewayServiceProxy.getKinesisMethodIntegration(
@@ -352,6 +374,9 @@ describe('#compileMethodsToKinesis()', () => {
             streamName: 'myStream',
             path: 'kinesis',
             method: 'post'
+          },
+          auth: {
+            authorizationType: 'NONE'
           }
         }
       ]
@@ -366,5 +391,213 @@ describe('#compileMethodsToKinesis()', () => {
 
     await expect(serverlessApigatewayServiceProxy.compileMethodsToKinesis()).to.be.fulfilled
     expect(serverless.service.provider.compiledCloudFormationTemplate.Resources).to.be.empty
+  })
+
+  it('should create corresponding resources with "CUSTOM" authorization type', async () => {
+    serverlessApigatewayServiceProxy.validated = {
+      events: [
+        {
+          serviceName: 'kinesis',
+          http: {
+            streamName: 'myStream',
+            path: 'kinesis',
+            method: 'post',
+            auth: {
+              authorizationType: 'CUSTOM',
+              authorizerId: { Ref: 'AuthorizerLogicalId' }
+            }
+          }
+        }
+      ]
+    }
+    serverlessApigatewayServiceProxy.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi'
+    serverlessApigatewayServiceProxy.apiGatewayResources = {
+      kinesis: {
+        name: 'kinesis',
+        resourceLogicalId: 'ApiGatewayResourceKinesis'
+      }
+    }
+
+    await expect(serverlessApigatewayServiceProxy.compileMethodsToKinesis()).to.be.fulfilled
+
+    expect(serverless.service.provider.compiledCloudFormationTemplate.Resources).to.deep.equal({
+      ApiGatewayMethodkinesisPost: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'POST',
+          RequestParameters: {},
+          AuthorizationType: 'CUSTOM',
+          AuthorizationScopes: undefined,
+          AuthorizerId: { Ref: 'AuthorizerLogicalId' },
+          ApiKeyRequired: false,
+          ResourceId: { Ref: 'ApiGatewayResourceKinesis' },
+          RestApiId: { Ref: 'ApiGatewayRestApi' },
+          Integration: {
+            IntegrationHttpMethod: 'POST',
+            Type: 'AWS',
+            Credentials: { 'Fn::GetAtt': ['ApigatewayToKinesisRole', 'Arn'] },
+            Uri: {
+              'Fn::Join': [
+                '',
+                ['arn:aws:apigateway:', { Ref: 'AWS::Region' }, ':kinesis:action/PutRecord']
+              ]
+            },
+            PassthroughBehavior: 'NEVER',
+            RequestTemplates: {
+              'application/json': {
+                'Fn::Join': [
+                  '',
+                  [
+                    '{',
+                    '"StreamName": "',
+                    '"myStream"',
+                    '",',
+                    '"Data": "$util.base64Encode($input.json(\'$.Data\'))",',
+                    '"PartitionKey": "$input.path(\'$.PartitionKey\')"',
+                    '}'
+                  ]
+                ]
+              },
+              'application/x-www-form-urlencoded': {
+                'Fn::Join': [
+                  '',
+                  [
+                    '{',
+                    '"StreamName": "',
+                    '"myStream"',
+                    '",',
+                    '"Data": "$util.base64Encode($input.json(\'$.Data\'))",',
+                    '"PartitionKey": "$input.path(\'$.PartitionKey\')"',
+                    '}'
+                  ]
+                ]
+              }
+            },
+            IntegrationResponses: [
+              {
+                StatusCode: 200,
+                SelectionPattern: 200,
+                ResponseParameters: {},
+                ResponseTemplates: {}
+              },
+              {
+                StatusCode: 400,
+                SelectionPattern: 400,
+                ResponseParameters: {},
+                ResponseTemplates: {}
+              }
+            ]
+          },
+          MethodResponses: [
+            { ResponseParameters: {}, ResponseModels: {}, StatusCode: 200 },
+            { ResponseParameters: {}, ResponseModels: {}, StatusCode: 400 }
+          ]
+        }
+      }
+    })
+  })
+
+  it('should create corresponding resources with "COGNITO_USER_POOLS" authorization type', async () => {
+    serverlessApigatewayServiceProxy.validated = {
+      events: [
+        {
+          serviceName: 'kinesis',
+          http: {
+            streamName: 'myStream',
+            path: 'kinesis',
+            method: 'post',
+            auth: {
+              authorizationType: 'COGNITO_USER_POOLS',
+              AuthorizationScopes: ['admin']
+            }
+          }
+        }
+      ]
+    }
+    serverlessApigatewayServiceProxy.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi'
+    serverlessApigatewayServiceProxy.apiGatewayResources = {
+      kinesis: {
+        name: 'kinesis',
+        resourceLogicalId: 'ApiGatewayResourceKinesis'
+      }
+    }
+
+    await expect(serverlessApigatewayServiceProxy.compileMethodsToKinesis()).to.be.fulfilled
+
+    expect(serverless.service.provider.compiledCloudFormationTemplate.Resources).to.deep.equal({
+      ApiGatewayMethodkinesisPost: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'POST',
+          RequestParameters: {},
+          AuthorizationType: 'COGNITO_USER_POOLS',
+          AuthorizationScopes: undefined,
+          AuthorizerId: undefined,
+          ApiKeyRequired: false,
+          ResourceId: { Ref: 'ApiGatewayResourceKinesis' },
+          RestApiId: { Ref: 'ApiGatewayRestApi' },
+          Integration: {
+            IntegrationHttpMethod: 'POST',
+            Type: 'AWS',
+            Credentials: { 'Fn::GetAtt': ['ApigatewayToKinesisRole', 'Arn'] },
+            Uri: {
+              'Fn::Join': [
+                '',
+                ['arn:aws:apigateway:', { Ref: 'AWS::Region' }, ':kinesis:action/PutRecord']
+              ]
+            },
+            PassthroughBehavior: 'NEVER',
+            RequestTemplates: {
+              'application/json': {
+                'Fn::Join': [
+                  '',
+                  [
+                    '{',
+                    '"StreamName": "',
+                    '"myStream"',
+                    '",',
+                    '"Data": "$util.base64Encode($input.json(\'$.Data\'))",',
+                    '"PartitionKey": "$input.path(\'$.PartitionKey\')"',
+                    '}'
+                  ]
+                ]
+              },
+              'application/x-www-form-urlencoded': {
+                'Fn::Join': [
+                  '',
+                  [
+                    '{',
+                    '"StreamName": "',
+                    '"myStream"',
+                    '",',
+                    '"Data": "$util.base64Encode($input.json(\'$.Data\'))",',
+                    '"PartitionKey": "$input.path(\'$.PartitionKey\')"',
+                    '}'
+                  ]
+                ]
+              }
+            },
+            IntegrationResponses: [
+              {
+                StatusCode: 200,
+                SelectionPattern: 200,
+                ResponseParameters: {},
+                ResponseTemplates: {}
+              },
+              {
+                StatusCode: 400,
+                SelectionPattern: 400,
+                ResponseParameters: {},
+                ResponseTemplates: {}
+              }
+            ]
+          },
+          MethodResponses: [
+            { ResponseParameters: {}, ResponseModels: {}, StatusCode: 200 },
+            { ResponseParameters: {}, ResponseModels: {}, StatusCode: 400 }
+          ]
+        }
+      }
+    })
   })
 })

--- a/lib/package/sqs/compileMethodsToSqs.js
+++ b/lib/package/sqs/compileMethodsToSqs.js
@@ -15,7 +15,9 @@ module.exports = {
           Properties: {
             HttpMethod: event.http.method.toUpperCase(),
             RequestParameters: {},
-            AuthorizationType: 'NONE',
+            AuthorizationScopes: event.http.auth.authorizationScopes,
+            AuthorizationType: event.http.auth.authorizationType,
+            AuthorizerId: event.http.auth.authorizerId,
             ApiKeyRequired: Boolean(event.http.private),
             ResourceId: resourceId,
             RestApiId: this.provider.getApiGatewayRestApiId()

--- a/lib/package/sqs/compileMethodsToSqs.test.js
+++ b/lib/package/sqs/compileMethodsToSqs.test.js
@@ -33,7 +33,10 @@ describe('#compileIamRoleToSqs()', () => {
           http: {
             queueName: 'myQueue',
             path: 'sqs',
-            method: 'post'
+            method: 'post',
+            auth: {
+              authorizationType: 'NONE'
+            }
           }
         }
       ]
@@ -54,6 +57,8 @@ describe('#compileIamRoleToSqs()', () => {
           HttpMethod: 'POST',
           RequestParameters: {},
           AuthorizationType: 'NONE',
+          AuthorizationScopes: undefined,
+          AuthorizerId: undefined,
           ApiKeyRequired: false,
           ResourceId: { Ref: 'ApiGatewayResourceSqs' },
           RestApiId: { Ref: 'ApiGatewayRestApi' },
@@ -112,6 +117,9 @@ describe('#compileIamRoleToSqs()', () => {
             queueName: 'myQueue',
             path: 'sqs',
             method: 'post',
+            auth: {
+              authorizationType: 'NONE'
+            },
             cors: {
               origins: ['*'],
               origin: '*',
@@ -146,6 +154,8 @@ describe('#compileIamRoleToSqs()', () => {
           HttpMethod: 'POST',
           RequestParameters: {},
           AuthorizationType: 'NONE',
+          AuthorizationScopes: undefined,
+          AuthorizerId: undefined,
           ApiKeyRequired: false,
           ResourceId: { Ref: 'ApiGatewayResourceSqs' },
           RestApiId: { Ref: 'ApiGatewayRestApi' },
@@ -197,6 +207,174 @@ describe('#compileIamRoleToSqs()', () => {
               ResponseModels: {},
               StatusCode: 400
             }
+          ]
+        }
+      }
+    })
+  })
+
+  it('should create corresponding resources with "CUSTOM" authorization type', async () => {
+    serverlessApigatewayServiceProxy.validated = {
+      events: [
+        {
+          serviceName: 'sqs',
+          http: {
+            queueName: 'myQueue',
+            path: 'sqs',
+            method: 'post',
+            auth: {
+              authorizationType: 'CUSTOM',
+              authorizerId: { Ref: 'AuthorizerLogicalId' }
+            }
+          }
+        }
+      ]
+    }
+    serverlessApigatewayServiceProxy.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi'
+    serverlessApigatewayServiceProxy.apiGatewayResources = {
+      sqs: {
+        name: 'sqs',
+        resourceLogicalId: 'ApiGatewayResourceSqs'
+      }
+    }
+
+    await expect(serverlessApigatewayServiceProxy.compileMethodsToSqs()).to.be.fulfilled
+    expect(serverless.service.provider.compiledCloudFormationTemplate.Resources).to.deep.equal({
+      ApiGatewayMethodsqsPost: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'POST',
+          RequestParameters: {},
+          AuthorizationType: 'CUSTOM',
+          AuthorizationScopes: undefined,
+          AuthorizerId: { Ref: 'AuthorizerLogicalId' },
+          ApiKeyRequired: false,
+          ResourceId: { Ref: 'ApiGatewayResourceSqs' },
+          RestApiId: { Ref: 'ApiGatewayRestApi' },
+          Integration: {
+            IntegrationHttpMethod: 'POST',
+            Type: 'AWS',
+            Credentials: { 'Fn::GetAtt': ['ApigatewayToSqsRole', 'Arn'] },
+            Uri: {
+              'Fn::Join': [
+                '',
+                [
+                  'arn:aws:apigateway:',
+                  { Ref: 'AWS::Region' },
+                  ':sqs:path//',
+                  { Ref: 'AWS::AccountId' },
+                  '/',
+                  '"myQueue"'
+                ]
+              ]
+            },
+            RequestParameters: {
+              'integration.request.querystring.Action': "'SendMessage'",
+              'integration.request.querystring.MessageBody': 'method.request.body'
+            },
+            RequestTemplates: { 'application/json': '{statusCode:200}' },
+            IntegrationResponses: [
+              {
+                StatusCode: 200,
+                SelectionPattern: 200,
+                ResponseParameters: {},
+                ResponseTemplates: {}
+              },
+              {
+                StatusCode: 400,
+                SelectionPattern: 400,
+                ResponseParameters: {},
+                ResponseTemplates: {}
+              }
+            ]
+          },
+          MethodResponses: [
+            { ResponseParameters: {}, ResponseModels: {}, StatusCode: 200 },
+            { ResponseParameters: {}, ResponseModels: {}, StatusCode: 400 }
+          ]
+        }
+      }
+    })
+  })
+
+  it('should create corresponding resources with "COGNITO_USER_POOLS" authorization type', async () => {
+    serverlessApigatewayServiceProxy.validated = {
+      events: [
+        {
+          serviceName: 'sqs',
+          http: {
+            queueName: 'myQueue',
+            path: 'sqs',
+            method: 'post',
+            auth: {
+              authorizationType: 'COGNITO_USER_POOLS',
+              authorizationScopes: ['admin']
+            }
+          }
+        }
+      ]
+    }
+    serverlessApigatewayServiceProxy.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi'
+    serverlessApigatewayServiceProxy.apiGatewayResources = {
+      sqs: {
+        name: 'sqs',
+        resourceLogicalId: 'ApiGatewayResourceSqs'
+      }
+    }
+
+    await expect(serverlessApigatewayServiceProxy.compileMethodsToSqs()).to.be.fulfilled
+    expect(serverless.service.provider.compiledCloudFormationTemplate.Resources).to.deep.equal({
+      ApiGatewayMethodsqsPost: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'POST',
+          RequestParameters: {},
+          AuthorizationType: 'COGNITO_USER_POOLS',
+          AuthorizationScopes: ['admin'],
+          AuthorizerId: undefined,
+          ApiKeyRequired: false,
+          ResourceId: { Ref: 'ApiGatewayResourceSqs' },
+          RestApiId: { Ref: 'ApiGatewayRestApi' },
+          Integration: {
+            IntegrationHttpMethod: 'POST',
+            Type: 'AWS',
+            Credentials: { 'Fn::GetAtt': ['ApigatewayToSqsRole', 'Arn'] },
+            Uri: {
+              'Fn::Join': [
+                '',
+                [
+                  'arn:aws:apigateway:',
+                  { Ref: 'AWS::Region' },
+                  ':sqs:path//',
+                  { Ref: 'AWS::AccountId' },
+                  '/',
+                  '"myQueue"'
+                ]
+              ]
+            },
+            RequestParameters: {
+              'integration.request.querystring.Action': "'SendMessage'",
+              'integration.request.querystring.MessageBody': 'method.request.body'
+            },
+            RequestTemplates: { 'application/json': '{statusCode:200}' },
+            IntegrationResponses: [
+              {
+                StatusCode: 200,
+                SelectionPattern: 200,
+                ResponseParameters: {},
+                ResponseTemplates: {}
+              },
+              {
+                StatusCode: 400,
+                SelectionPattern: 400,
+                ResponseParameters: {},
+                ResponseTemplates: {}
+              }
+            ]
+          },
+          MethodResponses: [
+            { ResponseParameters: {}, ResponseModels: {}, StatusCode: 200 },
+            { ResponseParameters: {}, ResponseModels: {}, StatusCode: 400 }
           ]
         }
       }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "lint": "eslint .",
     "integration-test": "jest --maxWorkers=5 integration",
     "test": "istanbul cover -x '**/*.test.js' node_modules/mocha/bin/_mocha '!(node_modules)/**/*.test.js' -- -R spec --recursive",
+    "test:watch": "_mocha '!(node_modules)/**/*.test.js' --watch",
     "fmt": "eslint . --fix --cache"
   },
   "husky": {


### PR DESCRIPTION
Fixes #11

Note to @horike37 : 
If `authorizationType` is set to `CUSTOM` I'm not creating the authorizer resource (If that is what you meant in your comment to #11).

I think it might be better if one defines the authorizer explicitly, but maybe we can wait for more use cases.

I'm actually using `AWS_IAM` (I wrote a [plugin](https://github.com/erezrokah/serverless-plugin-api-gateway-integrations) before noticing this one exists...).