### PR TITLE
Add missing 'DataType' request parameter mapping in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,4 +236,5 @@ custom:
           'integration.request.querystring.MessageAttribute.1.Value.DataType': "'String'"
           'integration.request.querystring.MessageAttribute.2.Name': "'cognitoAuthenticationProvider'"
           'integration.request.querystring.MessageAttribute.2.Value.StringValue': 'context.identity.cognitoAuthenticationProvider'
+          'integration.request.querystring.MessageAttribute.2.Value.DataType': "'String'"
 ```


### PR DESCRIPTION
fixes a `README` copy paste error introduced in https://github.com/horike37/serverless-apigateway-service-proxy/pull/16