### PR TITLE
feat: change default behavior of kinesis proxy

### DIFF
--- a/__tests__/integration/kinesis/multiple-integrations/service/serverless.yml
+++ b/__tests__/integration/kinesis/multiple-integrations/service/serverless.yml
@@ -14,32 +14,39 @@ custom:
     - kinesis:
         path: /kinesis1
         method: post
-        streamName: { Ref: 'YourStream1' }
+        streamName: { Ref: 'YourStream' }
         cors: true
-
     - kinesis:
         path: /kinesis2
         method: post
-        streamName: { Ref: 'YourStream2' }
+        partitionKey: 'hardcordedkey' # use static partitionkey
+        streamName: { Ref: 'YourStream' }
         cors: true
-
     - kinesis:
-        path: /kinesis3
+        path: /kinesis3/{myKey} # use path parameter
         method: post
-        streamName: { Ref: 'YourStream3' }
+        partitionKey:
+          pathParam: myKey
+        streamName: { Ref: 'YourStream' }
+        cors: true
+    - kinesis:
+        path: /kinesis4
+        method: post
+        partitionKey:
+          bodyParam: data.myKey # use body parameter
+        streamName: { Ref: 'YourStream' }
+        cors: true
+    - kinesis:
+        path: /kinesis5
+        method: post
+        partitionKey:
+          queryStringParam: myKey # use query string param
+        streamName: { Ref: 'YourStream' }
         cors: true
 
 resources:
   Resources:
-    YourStream1:
-      Type: AWS::Kinesis::Stream
-      Properties:
-        ShardCount: 1
-    YourStream2:
-      Type: AWS::Kinesis::Stream
-      Properties:
-        ShardCount: 1
-    YourStream3:
+    YourStream:
       Type: AWS::Kinesis::Stream
       Properties:
         ShardCount: 1

--- a/__tests__/integration/kinesis/multiple-integrations/tests.js
+++ b/__tests__/integration/kinesis/multiple-integrations/tests.js
@@ -19,22 +19,81 @@ describe('Multiple Kinesis Proxy Integrations Test', () => {
     removeService(stage, config)
   })
 
-  it('should get correct response from multiple kinesis proxy endpoints', async () => {
-    const streams = ['kinesis1', 'kinesis2', 'kinesis3']
+  it('should get correct response from kinesis proxy endpoints with default partitionkey', async () => {
+    const stream = 'kinesis1'
+    const testEndpoint = `${endpoint}/${stream}`
+    const response = await fetch(testEndpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: `data for stream ${stream}` })
+    })
+    expect(response.headers.get('access-control-allow-origin')).to.deep.equal('*')
+    expect(response.status).to.be.equal(200)
+    const body = await response.json()
+    expect(body).to.have.own.property('ShardId')
+    expect(body).to.have.own.property('SequenceNumber')
+  })
 
-    for (const stream of streams) {
-      const testEndpoint = `${endpoint}/${stream}`
+  it('should get correct response from kinesis proxy endpoints with hardcorded partitionkey', async () => {
+    const stream = 'kinesis2'
+    const testEndpoint = `${endpoint}/${stream}`
+    const response = await fetch(testEndpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: `data for stream ${stream}` })
+    })
+    expect(response.headers.get('access-control-allow-origin')).to.deep.equal('*')
+    expect(response.status).to.be.equal(200)
+    const body = await response.json()
+    expect(body).to.have.own.property('ShardId')
+    expect(body).to.have.own.property('SequenceNumber')
+  })
 
-      const response = await fetch(testEndpoint, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ Data: `data for stream ${stream}`, PartitionKey: 'some key' })
-      })
-      expect(response.headers.get('access-control-allow-origin')).to.deep.equal('*')
-      expect(response.status).to.be.equal(200)
-      const body = await response.json()
-      expect(body).to.have.own.property('ShardId')
-      expect(body).to.have.own.property('SequenceNumber')
-    }
+  it('should get correct response from kinesis proxy endpoints with pathparam partitionkey', async () => {
+    const stream = 'kinesis3'
+    const partitionkey = 'partitionkey'
+    const testEndpoint = `${endpoint}/${stream}/${partitionkey}`
+    const response = await fetch(testEndpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: `data for stream ${stream}` })
+    })
+    expect(response.headers.get('access-control-allow-origin')).to.deep.equal('*')
+    expect(response.status).to.be.equal(200)
+    const body = await response.json()
+    expect(body).to.have.own.property('ShardId')
+    expect(body).to.have.own.property('SequenceNumber')
+  })
+
+  it('should get correct response from kinesis proxy endpoints with bodyparam partitionkey', async () => {
+    const stream = 'kinesis4'
+    const partitionkey = 'partitionkey'
+    const testEndpoint = `${endpoint}/${stream}`
+    const response = await fetch(testEndpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: `data for stream ${stream}`, data: { myKey: partitionkey } })
+    })
+    expect(response.headers.get('access-control-allow-origin')).to.deep.equal('*')
+    expect(response.status).to.be.equal(200)
+    const body = await response.json()
+    expect(body).to.have.own.property('ShardId')
+    expect(body).to.have.own.property('SequenceNumber')
+  })
+
+  it('should get correct response from kinesis proxy endpoints with queryStringParam partitionkey', async () => {
+    const stream = 'kinesis5'
+    const partitionkey = 'partitionkey'
+    const testEndpoint = `${endpoint}/${stream}?myKey=${partitionkey}`
+    const response = await fetch(testEndpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: `data for stream ${stream}`, data: { mykey: partitionkey } })
+    })
+    expect(response.headers.get('access-control-allow-origin')).to.deep.equal('*')
+    expect(response.status).to.be.equal(200)
+    const body = await response.json()
+    expect(body).to.have.own.property('ShardId')
+    expect(body).to.have.own.property('SequenceNumber')
   })
 })

--- a/__tests__/integration/kinesis/single-integration/tests.js
+++ b/__tests__/integration/kinesis/single-integration/tests.js
@@ -25,7 +25,7 @@ describe('Single Kinesis Proxy Integration Test', () => {
     const response = await fetch(testEndpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ Data: 'some data', PartitionKey: 'some key' })
+      body: JSON.stringify({ message: 'some data' })
     })
     expect(response.headers.get('access-control-allow-origin')).to.deep.equal('*')
     expect(response.status).to.be.equal(200)

--- a/lib/package/kinesis/compileMethodsToKinesis.js
+++ b/lib/package/kinesis/compileMethodsToKinesis.js
@@ -126,6 +126,26 @@ module.exports = {
     }
   },
 
+  getKinesisObjectRequestParameter(http) {
+    if (!_.has(http, 'partitionKey')) {
+      return '$context.requestId'
+    }
+
+    if (http.partitionKey.pathParam) {
+      return `$input.params().path.${http.partitionKey.pathParam}`
+    }
+
+    if (http.partitionKey.queryStringParam) {
+      return `$input.params().querystring.${http.partitionKey.queryStringParam}`
+    }
+
+    if (http.partitionKey.bodyParam) {
+      return `$util.parseJson($input.body).${http.partitionKey.bodyParam}`
+    }
+
+    return `${http.partitionKey}`
+  },
+
   buildDefaultKinesisRequestTemplate(http) {
     let streamName
     if (typeof http.streamName == 'object') {
@@ -133,6 +153,8 @@ module.exports = {
     } else {
       streamName = `"${http.streamName}"`
     }
+
+    const objectRequestParam = this.getKinesisObjectRequestParameter(http)
 
     return {
       'Fn::Join': [
@@ -142,8 +164,8 @@ module.exports = {
           '"StreamName": "',
           streamName,
           '",',
-          '"Data": "$util.base64Encode($input.json(\'$.Data\'))",',
-          '"PartitionKey": "$input.path(\'$.PartitionKey\')"',
+          '"Data": "$util.base64Encode($input.body)",',
+          `"PartitionKey": "${objectRequestParam}"`,
           '}'
         ]
       ]

--- a/lib/package/kinesis/compileMethodsToKinesis.test.js
+++ b/lib/package/kinesis/compileMethodsToKinesis.test.js
@@ -85,8 +85,8 @@ describe('#compileMethodsToKinesis()', () => {
                     '"StreamName": "',
                     '"myStream"',
                     '",',
-                    '"Data": "$util.base64Encode($input.json(\'$.Data\'))",',
-                    '"PartitionKey": "$input.path(\'$.PartitionKey\')"',
+                    '"Data": "$util.base64Encode($input.body)",',
+                    '"PartitionKey": "$context.requestId"',
                     '}'
                   ]
                 ]
@@ -99,8 +99,8 @@ describe('#compileMethodsToKinesis()', () => {
                     '"StreamName": "',
                     '"myStream"',
                     '",',
-                    '"Data": "$util.base64Encode($input.json(\'$.Data\'))",',
-                    '"PartitionKey": "$input.path(\'$.PartitionKey\')"',
+                    '"Data": "$util.base64Encode($input.body)",',
+                    '"PartitionKey": "$context.requestId"',
                     '}'
                   ]
                 ]
@@ -209,8 +209,8 @@ describe('#compileMethodsToKinesis()', () => {
                     '"StreamName": "',
                     '"myStream"',
                     '",',
-                    '"Data": "$util.base64Encode($input.json(\'$.Data\'))",',
-                    '"PartitionKey": "$input.path(\'$.PartitionKey\')"',
+                    '"Data": "$util.base64Encode($input.body)",',
+                    '"PartitionKey": "$context.requestId"',
                     '}'
                   ]
                 ]
@@ -223,8 +223,8 @@ describe('#compileMethodsToKinesis()', () => {
                     '"StreamName": "',
                     '"myStream"',
                     '",',
-                    '"Data": "$util.base64Encode($input.json(\'$.Data\'))",',
-                    '"PartitionKey": "$input.path(\'$.PartitionKey\')"',
+                    '"Data": "$util.base64Encode($input.body)",',
+                    '"PartitionKey": "$context.requestId"',
                     '}'
                   ]
                 ]
@@ -300,8 +300,168 @@ describe('#compileMethodsToKinesis()', () => {
         '"StreamName": "',
         '"undefined"',
         '",',
-        '"Data": "$util.base64Encode($input.json(\'$.Data\'))",',
-        '"PartitionKey": "$input.path(\'$.PartitionKey\')"',
+        '"Data": "$util.base64Encode($input.body)",',
+        '"PartitionKey": "$context.requestId"',
+        '}'
+      ]
+    ])
+  })
+
+  it('should set path parameter to partitionkey when pathParam is given', async () => {
+    const httpWithoutRequestTemplate = {
+      path: 'foo/{key1}',
+      method: 'post',
+      partitionKey: {
+        pathParam: 'key1'
+      },
+      streamName: 'testStream',
+      auth: {
+        authorizationType: 'NONE'
+      }
+    }
+
+    const resource = await serverlessApigatewayServiceProxy.getKinesisMethodIntegration(
+      httpWithoutRequestTemplate
+    )
+
+    expect(
+      resource.Properties.Integration.RequestTemplates['application/json']['Fn::Join']
+    ).to.be.deep.equal([
+      '',
+      [
+        '{',
+        '"StreamName": "',
+        '"testStream"',
+        '",',
+        '"Data": "$util.base64Encode($input.body)",',
+        '"PartitionKey": "$input.params().path.key1"',
+        '}'
+      ]
+    ])
+  })
+
+  it('should set body parameter to partitionkey when bodyParam is given', async () => {
+    const httpWithoutRequestTemplate = {
+      path: 'foo',
+      method: 'post',
+      partitionKey: {
+        bodyParam: 'data.messageId'
+      },
+      streamName: 'testStream',
+      auth: {
+        authorizationType: 'NONE'
+      }
+    }
+
+    const resource = await serverlessApigatewayServiceProxy.getKinesisMethodIntegration(
+      httpWithoutRequestTemplate
+    )
+
+    expect(
+      resource.Properties.Integration.RequestTemplates['application/json']['Fn::Join']
+    ).to.be.deep.equal([
+      '',
+      [
+        '{',
+        '"StreamName": "',
+        '"testStream"',
+        '",',
+        '"Data": "$util.base64Encode($input.body)",',
+        '"PartitionKey": "$util.parseJson($input.body).data.messageId"',
+        '}'
+      ]
+    ])
+  })
+
+  it('should set querystring parameter to partitionkey when queryStringParam is given', async () => {
+    const httpWithoutRequestTemplate = {
+      path: 'foo?key=xxxxx',
+      method: 'post',
+      partitionKey: {
+        queryStringParam: 'key'
+      },
+      streamName: 'testStream',
+      auth: {
+        authorizationType: 'NONE'
+      }
+    }
+
+    const resource = await serverlessApigatewayServiceProxy.getKinesisMethodIntegration(
+      httpWithoutRequestTemplate
+    )
+
+    expect(
+      resource.Properties.Integration.RequestTemplates['application/json']['Fn::Join']
+    ).to.be.deep.equal([
+      '',
+      [
+        '{',
+        '"StreamName": "',
+        '"testStream"',
+        '",',
+        '"Data": "$util.base64Encode($input.body)",',
+        '"PartitionKey": "$input.params().querystring.key"',
+        '}'
+      ]
+    ])
+  })
+
+  it('should set apigateway requestid to partitionkey when no one is given', async () => {
+    const httpWithoutRequestTemplate = {
+      path: 'foo',
+      method: 'post',
+      streamName: 'testStream',
+      auth: {
+        authorizationType: 'NONE'
+      }
+    }
+
+    const resource = await serverlessApigatewayServiceProxy.getKinesisMethodIntegration(
+      httpWithoutRequestTemplate
+    )
+
+    expect(
+      resource.Properties.Integration.RequestTemplates['application/json']['Fn::Join']
+    ).to.be.deep.equal([
+      '',
+      [
+        '{',
+        '"StreamName": "',
+        '"testStream"',
+        '",',
+        '"Data": "$util.base64Encode($input.body)",',
+        '"PartitionKey": "$context.requestId"',
+        '}'
+      ]
+    ])
+  })
+
+  it('should set specified value to partitionkey when the param is hardcorded', async () => {
+    const httpWithoutRequestTemplate = {
+      path: 'foo',
+      method: 'post',
+      streamName: 'testStream',
+      partitionKey: 'mykey',
+      auth: {
+        authorizationType: 'NONE'
+      }
+    }
+
+    const resource = await serverlessApigatewayServiceProxy.getKinesisMethodIntegration(
+      httpWithoutRequestTemplate
+    )
+
+    expect(
+      resource.Properties.Integration.RequestTemplates['application/json']['Fn::Join']
+    ).to.be.deep.equal([
+      '',
+      [
+        '{',
+        '"StreamName": "',
+        '"testStream"',
+        '",',
+        '"Data": "$util.base64Encode($input.body)",',
+        '"PartitionKey": "mykey"',
         '}'
       ]
     ])
@@ -355,8 +515,8 @@ describe('#compileMethodsToKinesis()', () => {
         '"StreamName": "',
         '"undefined"',
         '",',
-        '"Data": "$util.base64Encode($input.json(\'$.Data\'))",',
-        '"PartitionKey": "$input.path(\'$.PartitionKey\')"',
+        '"Data": "$util.base64Encode($input.body)",',
+        '"PartitionKey": "$context.requestId"',
         '}'
       ]
     ])
@@ -470,8 +630,8 @@ describe('#compileMethodsToKinesis()', () => {
                     '"StreamName": "',
                     '"myStream"',
                     '",',
-                    '"Data": "$util.base64Encode($input.json(\'$.Data\'))",',
-                    '"PartitionKey": "$input.path(\'$.PartitionKey\')"',
+                    '"Data": "$util.base64Encode($input.body)",',
+                    '"PartitionKey": "$context.requestId"',
                     '}'
                   ]
                 ]
@@ -484,8 +644,8 @@ describe('#compileMethodsToKinesis()', () => {
                     '"StreamName": "',
                     '"myStream"',
                     '",',
-                    '"Data": "$util.base64Encode($input.json(\'$.Data\'))",',
-                    '"PartitionKey": "$input.path(\'$.PartitionKey\')"',
+                    '"Data": "$util.base64Encode($input.body)",',
+                    '"PartitionKey": "$context.requestId"',
                     '}'
                   ]
                 ]
@@ -581,8 +741,8 @@ describe('#compileMethodsToKinesis()', () => {
                     '"StreamName": "',
                     '"myStream"',
                     '",',
-                    '"Data": "$util.base64Encode($input.json(\'$.Data\'))",',
-                    '"PartitionKey": "$input.path(\'$.PartitionKey\')"',
+                    '"Data": "$util.base64Encode($input.body)",',
+                    '"PartitionKey": "$context.requestId"',
                     '}'
                   ]
                 ]
@@ -595,8 +755,8 @@ describe('#compileMethodsToKinesis()', () => {
                     '"StreamName": "',
                     '"myStream"',
                     '",',
-                    '"Data": "$util.base64Encode($input.json(\'$.Data\'))",',
-                    '"PartitionKey": "$input.path(\'$.PartitionKey\')"',
+                    '"Data": "$util.base64Encode($input.body)",',
+                    '"PartitionKey": "$context.requestId"',
                     '}'
                   ]
                 ]

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "@hapi/joi": "^15.1.0",
     "serverless": "^1.48.2"
   },
+  "jest": {
+    "setupFilesAfterEnv": ["<rootDir>/__tests__/setup-tests.js"]
+  },
   "author": "horike37",
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
- Put whole body parameters into Kinesis record.
- Changed how to set partitionkey like the following:
   - By default, using aws request_id
   - `partitionKey` param is hardcorded, using it
   - `pathParam` is set to `partitionKey` param, using pathparameter in request URL path
   - `bodyParam` is set, using body parameter in request
   - `queryStringParam` is set, using query in request URL
