### PR TITLE
Feature: add sns support

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,10 @@ Source: [AWS::ApiGateway::Method docs](https://docs.aws.amazon.com/AWSCloudForma
 If you'd like to add content types or customize the default templates, you can do so by including your custom [API Gateway request mapping template](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html) in `serverless.yml` like so:
 
 ```yml
+# Required for using Fn::Sub
+plugins:
+  - serverless-cloudformation-sub-variables
+
 custom:
   apiGatewayServiceProxies:
     - kinesis:
@@ -344,6 +348,10 @@ Source: [How to connect SNS to Kinesis for cross-account delivery via API Gatewa
 Similar to the [Kinesis](#kinesis-1) support, you can customize the default request mapping templates in `serverless.yml` like so:
 
 ```yml
+# Required for using Fn::Sub
+plugins:
+  - serverless-cloudformation-sub-variables
+
 custom:
   apiGatewayServiceProxies:
     - kinesis:
@@ -353,11 +361,9 @@ custom:
         request:
           template:
             application/json:
-              'Fn::Join':
-                - ''
-                - - "Action=Publish&Message=$util.urlEncode('This is a fixed message')&TopicArn=$util.urlEncode('"
-                  - { Ref: MyTopic }
-                  - "')"
+              Fn::Sub:
+                - "Action=Publish&Message=$util.urlEncode('This is a fixed message')&TopicArn=$util.urlEncode('#{MyTopicArn}')"
+                - MyTopicArn: { Ref: MyTopic }
 ```
 
 > It is important that the mapping template will return a valid `application/x-www-form-urlencoded` string

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Please pull request if you are intersted in it.
 - Kinesis Streams
 - SQS
 - S3
+- SNS
 
 ## How to use
 
@@ -77,7 +78,7 @@ resources:
 Sample request after deploying.
 
 ```bash
-curl -X POST https://xxxxxxx.execute-api.us-east-1.amazonaws.com/dev/kinesis -d '{"message": "some data"}'  -H 'Content-Type:application/json'
+curl https://xxxxxxx.execute-api.us-east-1.amazonaws.com/dev/kinesis -d '{"message": "some data"}'  -H 'Content-Type:application/json'
 ```
 
 ### SQS
@@ -102,7 +103,7 @@ resources:
 Sample request after deploying.
 
 ```bash
-curl -X POST https://xxxxxx.execute-api.us-east-1.amazonaws.com/dev/sqs -d '{"message": "testtest"}' -H 'Content-Type:application/json'
+curl https://xxxxxx.execute-api.us-east-1.amazonaws.com/dev/sqs -d '{"message": "testtest"}' -H 'Content-Type:application/json'
 ```
 
 #### Customizing request parameters
@@ -172,7 +173,32 @@ resources:
 Sample request after deploying.
 
 ```bash
-curl -X POST https://xxxxxx.execute-api.us-east-1.amazonaws.com/dev/s3 -d '{"message": "testtest"}' -H 'Content-Type:application/json'
+curl https://xxxxxx.execute-api.us-east-1.amazonaws.com/dev/s3 -d '{"message": "testtest"}' -H 'Content-Type:application/json'
+```
+
+### SNS
+
+Sample syntax for SNS proxy in `serverless.yml`.
+
+```yaml
+custom:
+  apiGatewayServiceProxies:
+    - sns:
+        path: /sns
+        method: post
+        topicName: { 'Fn::GetAtt': ['SNSTopic', 'TopicName'] }
+        cors: true
+
+resources:
+  Resources:
+    SNSTopic:
+      Type: AWS::SNS::Topic
+```
+
+Sample request after deploying.
+
+```bash
+curl https://xxxxxx.execute-api.us-east-1.amazonaws.com/dev/sns -d '{"message": "testtest"}' -H 'Content-Type:application/json'
 ```
 
 ## Common API Gateway features
@@ -282,6 +308,8 @@ Source: [AWS::ApiGateway::Method docs](https://docs.aws.amazon.com/AWSCloudForma
 
 ### Customizing request body mapping templates
 
+#### Kinesis
+
 If you'd like to add content types or customize the default templates, you can do so by including your custom [API Gateway request mapping template](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html) in `serverless.yml` like so:
 
 ```yml
@@ -307,4 +335,31 @@ custom:
                     Fn::GetAtt: [MyStream, Arn]
 ```
 
+> It is important that the mapping template will return a valid `application/json` string
+
 Source: [How to connect SNS to Kinesis for cross-account delivery via API Gateway](https://theburningmonk.com/2019/07/how-to-connect-sns-to-kinesis-for-cross-account-delivery-via-api-gateway/)
+
+#### SNS
+
+Similar to the [Kinesis](#kinesis-1) support, you can customize the default request mapping templates in `serverless.yml` like so:
+
+```yml
+custom:
+  apiGatewayServiceProxies:
+    - kinesis:
+        path: /sns
+        method: post
+        topicName: { 'Fn::GetAtt': ['SNSTopic', 'TopicName'] }
+        request:
+          template:
+            application/json:
+              'Fn::Join':
+                - ''
+                - - "Action=Publish&Message=$util.urlEncode('This is a fixed message')&TopicArn=$util.urlEncode('"
+                  - { Ref: MyTopic }
+                  - "')"
+```
+
+> It is important that the mapping template will return a valid `application/x-www-form-urlencoded` string
+
+Source: [Connect AWS API Gateway directly to SNS using a service integration](https://www.alexdebrie.com/posts/aws-api-gateway-service-proxy/)

--- a/__tests__/integration/sns/custom-mapping-template/service/serverless.yml
+++ b/__tests__/integration/sns/custom-mapping-template/service/serverless.yml
@@ -1,0 +1,64 @@
+service: sns-proxy
+
+provider:
+  name: aws
+  runtime: nodejs10.x
+  stage: ${opt:stage, 'dev'}
+
+plugins:
+  localPath: './../../../../../../'
+  modules:
+    - serverless-apigateway-service-proxy
+
+custom:
+  apiGatewayServiceProxies:
+    - sns:
+        path: /sns
+        method: post
+        topicName: { 'Fn::GetAtt': ['SNSTopic', 'TopicName'] }
+        cors: true
+        request:
+          template:
+            application/json:
+              'Fn::Join':
+                - ''
+                - - "Action=Publish&Message=$util.urlEncode('This is a fixed message')&TopicArn=$util.urlEncode('"
+                  - { Ref: SNSTopic }
+                  - "')"
+
+resources:
+  Resources:
+    SNSTopic:
+      Type: AWS::SNS::Topic
+      Properties:
+        Subscription:
+          - Endpoint: { 'Fn::GetAtt': ['SqsQueue', 'Arn'] }
+            Protocol: sqs
+
+    SqsQueue:
+      Type: AWS::SQS::Queue
+
+    SqsQueuePolicy:
+      Type: AWS::SQS::QueuePolicy
+      Properties:
+        PolicyDocument:
+          Version: '2012-10-17'
+          Id: SqsQueuePolicy
+          Statement:
+            - Sid: Allow-SendMessage-To-Queue-From-SNS-Topic
+              Effect: Allow
+              Principal: "*"
+              Action:
+                - sqs:SendMessage
+              Resource: "*"
+              Condition:
+                ArnEquals:
+                  aws:SourceArn:
+                    Ref: SNSTopic
+
+        Queues:
+          - Ref: SqsQueue
+        
+  Outputs:
+    SqsQueueUrl:
+      Value: { Ref: SqsQueue }

--- a/__tests__/integration/sns/custom-mapping-template/tests.js
+++ b/__tests__/integration/sns/custom-mapping-template/tests.js
@@ -1,0 +1,61 @@
+'use strict'
+
+const { default: awsTesting } = require('aws-testing-library/lib/chai')
+const chai = require('chai')
+chai.use(awsTesting)
+const { expect } = chai
+
+const fetch = require('node-fetch')
+const { deployWithRandomStage, removeService } = require('../../../utils')
+
+describe('Single SNS Proxy Integration Test', () => {
+  let endpoint
+  let stage
+  let region
+  let queueUrl
+  const config = '__tests__/integration/sns/custom-mapping-template/service/serverless.yml'
+
+  beforeAll(async () => {
+    ;({
+      stage,
+      region,
+      endpoint,
+      outputs: { SqsQueueUrl: queueUrl }
+    } = await deployWithRandomStage(config))
+  })
+
+  afterAll(() => {
+    removeService(stage, config)
+  })
+
+  it('should get correct response from sqs proxy endpoint', async () => {
+    const testEndpoint = `${endpoint}/sns`
+
+    const response = await fetch(testEndpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' }
+    })
+
+    expect(response.headers.get('access-control-allow-origin')).to.deep.equal('*')
+    expect(response.status).to.be.equal(200)
+    const json = await response.json()
+
+    expect(json).to.have.own.property('PublishResponse')
+
+    expect(json.PublishResponse).to.have.own.property('PublishResult')
+    expect(json.PublishResponse).to.have.own.property('ResponseMetadata')
+
+    expect(json.PublishResponse.PublishResult).to.have.own.property('MessageId')
+    expect(json.PublishResponse.PublishResult).to.have.own.property('SequenceNumber')
+
+    expect(json.PublishResponse.ResponseMetadata).to.have.own.property('RequestId')
+
+    const expectedFixedMessage = 'This is a fixed message'
+    await expect({
+      region,
+      queueUrl,
+      timeout: 10000,
+      pollEvery: 2500
+    }).to.have.message((message) => message.Message === expectedFixedMessage)
+  })
+})

--- a/__tests__/integration/sns/multiple-integrations/service/serverless.yml
+++ b/__tests__/integration/sns/multiple-integrations/service/serverless.yml
@@ -1,0 +1,103 @@
+service: multiple-sns-proxy
+
+provider:
+  name: aws
+  runtime: nodejs10.x
+
+plugins:
+  localPath: './../../../../../../'
+  modules:
+    - serverless-apigateway-service-proxy
+
+custom:
+  apiGatewayServiceProxies:
+    - sns:
+        path: /sns1
+        method: post
+        topicName: { 'Fn::GetAtt': ['SNSTopic1', 'TopicName'] }
+        cors: true
+
+    - sns:
+        path: /sns2
+        method: post
+        topicName: { 'Fn::GetAtt': ['SNSTopic2', 'TopicName'] }
+        cors: true
+
+    - sns:
+        path: /sns3
+        method: post
+        topicName: { 'Fn::GetAtt': ['SNSTopic3', 'TopicName'] }
+        cors: true
+
+resources:
+  Resources:
+    SNSTopic1:
+      Type: AWS::SNS::Topic
+      Properties:
+        Subscription:
+          - Endpoint: { 'Fn::GetAtt': ['SqsQueue', 'Arn'] }
+            Protocol: sqs
+
+    SNSTopic2:
+      Type: AWS::SNS::Topic
+      Properties:
+        Subscription:
+          - Endpoint: { 'Fn::GetAtt': ['SqsQueue', 'Arn'] }
+            Protocol: sqs
+    
+    SNSTopic3:
+      Type: AWS::SNS::Topic
+      Properties:
+        Subscription:
+          - Endpoint: { 'Fn::GetAtt': ['SqsQueue', 'Arn'] }
+            Protocol: sqs
+
+    SqsQueue:
+      Type: AWS::SQS::Queue
+
+    SqsQueuePolicy:
+      Type: AWS::SQS::QueuePolicy
+      Properties:
+        PolicyDocument:
+          Version: '2012-10-17'
+          Id: SqsQueuePolicy
+          Statement:
+            - Sid: Allow-SendMessage-To-Queue-From-SNS-Topic1
+              Effect: Allow
+              Principal: "*"
+              Action:
+                - sqs:SendMessage
+              Resource: "*"
+              Condition:
+                ArnEquals:
+                  aws:SourceArn:
+                    Ref: SNSTopic1
+
+            - Sid: Allow-SendMessage-To-Queue-From-SNS-Topic2
+              Effect: Allow
+              Principal: "*"
+              Action:
+                - sqs:SendMessage
+              Resource: "*"
+              Condition:
+                ArnEquals:
+                  aws:SourceArn:
+                    Ref: SNSTopic2
+
+            - Sid: Allow-SendMessage-To-Queue-From-SNS-Topic3
+              Effect: Allow
+              Principal: "*"
+              Action:
+                - sqs:SendMessage
+              Resource: "*"
+              Condition:
+                ArnEquals:
+                  aws:SourceArn:
+                    Ref: SNSTopic3
+
+        Queues:
+          - Ref: SqsQueue
+        
+  Outputs:
+    SqsQueueUrl:
+      Value: { Ref: SqsQueue }

--- a/__tests__/integration/sns/multiple-integrations/tests.js
+++ b/__tests__/integration/sns/multiple-integrations/tests.js
@@ -1,0 +1,65 @@
+'use strict'
+
+const { default: awsTesting } = require('aws-testing-library/lib/chai')
+const chai = require('chai')
+chai.use(awsTesting)
+const { expect } = chai
+
+const fetch = require('node-fetch')
+const { deployWithRandomStage, removeService } = require('../../../utils')
+
+describe('Multiple SQS Proxy Integrations Test', () => {
+  let endpoint
+  let stage
+  let region
+  let queueUrl
+  const config = '__tests__/integration/sns/multiple-integrations/service/serverless.yml'
+
+  beforeAll(async () => {
+    ;({
+      stage,
+      region,
+      endpoint,
+      outputs: { SqsQueueUrl: queueUrl }
+    } = await deployWithRandomStage(config))
+  })
+
+  afterAll(() => {
+    removeService(stage, config)
+  })
+
+  it('should get correct response from multiple sqs proxy endpoints', async () => {
+    const topics = ['sns1', 'sns2', 'sns3']
+
+    for (const topic of topics) {
+      const testEndpoint = `${endpoint}/${topic}`
+
+      const body = JSON.stringify({ message: `message for ${topic}` })
+      const response = await fetch(testEndpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body
+      })
+      expect(response.headers.get('access-control-allow-origin')).to.deep.equal('*')
+      expect(response.status).to.be.equal(200)
+      const json = await response.json()
+
+      expect(json).to.have.own.property('PublishResponse')
+
+      expect(json.PublishResponse).to.have.own.property('PublishResult')
+      expect(json.PublishResponse).to.have.own.property('ResponseMetadata')
+
+      expect(json.PublishResponse.PublishResult).to.have.own.property('MessageId')
+      expect(json.PublishResponse.PublishResult).to.have.own.property('SequenceNumber')
+
+      expect(json.PublishResponse.ResponseMetadata).to.have.own.property('RequestId')
+
+      await expect({
+        region,
+        queueUrl,
+        timeout: 10000,
+        pollEvery: 2500
+      }).to.have.message((message) => message.Message === body)
+    }
+  })
+})

--- a/__tests__/integration/sns/single-integration/service/serverless.yml
+++ b/__tests__/integration/sns/single-integration/service/serverless.yml
@@ -1,0 +1,55 @@
+service: sns-proxy
+
+provider:
+  name: aws
+  runtime: nodejs10.x
+
+plugins:
+  localPath: './../../../../../../'
+  modules:
+    - serverless-apigateway-service-proxy
+
+custom:  
+  apiGatewayServiceProxies:
+    - sns:
+        path: /sns
+        method: post
+        topicName: { 'Fn::GetAtt': ['SNSTopic', 'TopicName'] }
+        cors: true
+
+resources:
+  Resources:
+    SNSTopic:
+      Type: AWS::SNS::Topic
+      Properties:
+        Subscription:
+          - Endpoint: { 'Fn::GetAtt': ['SqsQueue', 'Arn'] }
+            Protocol: sqs
+
+    SqsQueue:
+      Type: AWS::SQS::Queue      
+
+    SqsQueuePolicy:
+      Type: AWS::SQS::QueuePolicy
+      Properties:
+        PolicyDocument:
+          Version: '2012-10-17'
+          Id: SqsQueuePolicy
+          Statement:
+            - Sid: Allow-SendMessage-To-Queue-From-SNS-Topic
+              Effect: Allow
+              Principal: "*"
+              Action:
+                - sqs:SendMessage
+              Resource: "*"
+              Condition:
+                ArnEquals:
+                  aws:SourceArn:
+                    Ref: SNSTopic
+
+        Queues:
+          - Ref: SqsQueue
+
+  Outputs:
+    SqsQueueUrl:
+      Value: { Ref: SqsQueue }

--- a/__tests__/integration/sns/single-integration/tests.js
+++ b/__tests__/integration/sns/single-integration/tests.js
@@ -1,0 +1,62 @@
+'use strict'
+
+const { default: awsTesting } = require('aws-testing-library/lib/chai')
+const chai = require('chai')
+chai.use(awsTesting)
+const { expect } = chai
+
+const fetch = require('node-fetch')
+const { deployWithRandomStage, removeService } = require('../../../utils')
+
+describe('Single SNS Proxy Integration Test', () => {
+  let endpoint
+  let stage
+  let region
+  let queueUrl
+  const config = '__tests__/integration/sns/single-integration/service/serverless.yml'
+
+  beforeAll(async () => {
+    ;({
+      stage,
+      region,
+      endpoint,
+      outputs: { SqsQueueUrl: queueUrl }
+    } = await deployWithRandomStage(config))
+  })
+
+  afterAll(() => {
+    removeService(stage, config)
+  })
+
+  it('should get correct response from sqs proxy endpoint', async () => {
+    const testEndpoint = `${endpoint}/sns`
+
+    const body = JSON.stringify({ message: 'testtest' })
+    const response = await fetch(testEndpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body
+    })
+
+    expect(response.headers.get('access-control-allow-origin')).to.deep.equal('*')
+    expect(response.status).to.be.equal(200)
+    const json = await response.json()
+
+    expect(json).to.have.own.property('PublishResponse')
+
+    expect(json.PublishResponse).to.have.own.property('PublishResult')
+    expect(json.PublishResponse).to.have.own.property('ResponseMetadata')
+
+    expect(json.PublishResponse.PublishResult).to.have.own.property('MessageId')
+    expect(json.PublishResponse.PublishResult).to.have.own.property('SequenceNumber')
+
+    expect(json.PublishResponse.ResponseMetadata).to.have.own.property('RequestId')
+
+    await expect({
+      region,
+      queueUrl,
+      timeout: 10000,
+      pollEvery: 2500
+    }).to.have.message((message) => message.Message === body)
+  })
+})

--- a/__tests__/utils.js
+++ b/__tests__/utils.js
@@ -7,7 +7,9 @@ const path = require('path')
 const execSync = require('child_process').execSync
 const aws = require('aws-sdk')
 const s3 = new aws.S3()
-const cloudformation = new aws.CloudFormation({ region: 'us-east-1' })
+
+const region = 'us-east-1'
+const cloudformation = new aws.CloudFormation({ region })
 
 function getApiGatewayEndpoint(outputs) {
   return outputs.ServiceEndpoint.match(/https:\/\/.+\.execute-api\..+\.amazonaws\.com.+/)[0]
@@ -67,7 +69,7 @@ async function deployWithRandomStage(config) {
   const outputs = await getStackOutputs(stackName)
   const endpoint = getApiGatewayEndpoint(outputs)
 
-  return { stackName, stage, outputs, endpoint }
+  return { stackName, stage, outputs, endpoint, region }
 }
 
 module.exports = {

--- a/lib/apiGateway/validate.js
+++ b/lib/apiGateway/validate.js
@@ -51,7 +51,7 @@ module.exports = {
   },
 
   async checkAllowedService(serviceName) {
-    const allowedProxies = ['kinesis', 'sqs', 's3']
+    const allowedProxies = ['kinesis', 'sqs', 's3', 'sns']
     if (allowedProxies.indexOf(serviceName) === NOT_FOUND) {
       const errorMessage = [
         `Invalid APIG proxy "${serviceName}".`,

--- a/lib/apiGateway/validate.test.js
+++ b/lib/apiGateway/validate.test.js
@@ -37,7 +37,7 @@ describe('#validateServiceProxies()', () => {
     }
 
     await expect(serverlessApigatewayServiceProxy.validateServiceProxies()).to.be.rejectedWith(
-      'Invalid APIG proxy "xxxxx". This plugin supported Proxies are: kinesis, sqs, s3.'
+      'Invalid APIG proxy "xxxxx". This plugin supported Proxies are: kinesis, sqs, s3, sns.'
     )
   })
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,6 +26,11 @@ const compileMethodsToS3 = require('./package/s3/compileMethodsToS3')
 const compileIamRoleToS3 = require('./package/s3/compileIamRoleToS3')
 const validateS3ServiceProxy = require('./package/s3/validateS3ServiceProxy')
 const compileS3ServiceProxy = require('./package/s3/compileS3ServiceProxy')
+// SNS
+const compileMethodsToSns = require('./package/sns/compileMethodsToSns')
+const compileIamRoleToSns = require('./package/sns/compileIamRoleToSns')
+const validateSnsServiceProxy = require('./package/sns/validateSnsServiceProxy')
+const compileSnsServiceProxy = require('./package/sns/compileSnsServiceProxy')
 
 class ServerlessApigatewayServiceProxy {
   constructor(serverless, options) {
@@ -54,6 +59,10 @@ class ServerlessApigatewayServiceProxy {
       compileIamRoleToS3,
       compileS3ServiceProxy,
       validateS3ServiceProxy,
+      compileMethodsToSns,
+      compileIamRoleToSns,
+      validateSnsServiceProxy,
+      compileSnsServiceProxy,
       getStackInfo,
       validate,
       methods,
@@ -77,6 +86,9 @@ class ServerlessApigatewayServiceProxy {
 
           // S3 getProxy
           await this.compileS3ServiceProxy()
+
+          // SNS getProxy
+          await this.compileSnsServiceProxy()
 
           await this.mergeDeployment()
         }

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -70,6 +70,12 @@ describe('#index()', () => {
               path: '/s3',
               method: 'post'
             }
+          },
+          {
+            sns: {
+              path: '/sns',
+              method: 'post'
+            }
           }
         ]
       }
@@ -95,6 +101,9 @@ describe('#index()', () => {
       const compileS3ServiceProxyStub = sinon
         .stub(serverlessApigatewayServiceProxy, 'compileS3ServiceProxy')
         .returns(BbPromise.resolve())
+      const compileSnsServiceProxyStub = sinon
+        .stub(serverlessApigatewayServiceProxy, 'compileSnsServiceProxy')
+        .returns(BbPromise.resolve())
       const mergeDeploymentStub = sinon
         .stub(serverlessApigatewayServiceProxy, 'mergeDeployment')
         .returns(BbPromise.resolve())
@@ -109,6 +118,7 @@ describe('#index()', () => {
         expect(compileKinesisServiceProxyStub.calledOnce).to.be.equal(true)
         expect(compileSqsServiceProxyStub.calledOnce).to.be.equal(true)
         expect(compileS3ServiceProxyStub.calledOnce).to.be.equal(true)
+        expect(compileSnsServiceProxyStub.calledOnce).to.be.equal(true)
         expect(mergeDeploymentStub.calledOnce).to.be.equal(true)
       })
 
@@ -119,6 +129,7 @@ describe('#index()', () => {
       serverlessApigatewayServiceProxy.compileKinesisServiceProxy.restore()
       serverlessApigatewayServiceProxy.compileSqsServiceProxy.restore()
       serverlessApigatewayServiceProxy.compileS3ServiceProxy.restore()
+      serverlessApigatewayServiceProxy.compileSnsServiceProxy.restore()
       serverlessApigatewayServiceProxy.mergeDeployment.restore()
     })
 

--- a/lib/package/sns/compileIamRoleToSns.js
+++ b/lib/package/sns/compileIamRoleToSns.js
@@ -1,0 +1,64 @@
+'use strict'
+const _ = require('lodash')
+
+module.exports = {
+  compileIamRoleToSns() {
+    const topicNames = this.getAllServiceProxies()
+      .filter((serviceProxy) => this.getServiceName(serviceProxy) === 'sns')
+      .map((serviceProxy) => {
+        const serviceName = this.getServiceName(serviceProxy)
+        const { topicName } = serviceProxy[serviceName]
+        return topicName
+      })
+
+    if (topicNames.length <= 0) {
+      return
+    }
+
+    const policyResource = topicNames.map((topicName) => ({
+      'Fn::Sub': ['arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${topicName}', { topicName }]
+    }))
+
+    const template = {
+      Type: 'AWS::IAM::Role',
+      Properties: {
+        AssumeRolePolicyDocument: {
+          Version: '2012-10-17',
+          Statement: [
+            {
+              Effect: 'Allow',
+              Principal: {
+                Service: 'apigateway.amazonaws.com'
+              },
+              Action: 'sts:AssumeRole'
+            }
+          ]
+        },
+        Policies: [
+          {
+            PolicyName: 'apigatewaytosns',
+            PolicyDocument: {
+              Version: '2012-10-17',
+              Statement: [
+                {
+                  Effect: 'Allow',
+                  Action: ['logs:CreateLogGroup', 'logs:CreateLogStream', 'logs:PutLogEvents'],
+                  Resource: '*'
+                },
+                {
+                  Effect: 'Allow',
+                  Action: ['sns:Publish'],
+                  Resource: policyResource
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+
+    _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
+      ApigatewayToSnsRole: template
+    })
+  }
+}

--- a/lib/package/sns/compileIamRoleToSns.test.js
+++ b/lib/package/sns/compileIamRoleToSns.test.js
@@ -1,0 +1,134 @@
+'use strict'
+
+const chai = require('chai')
+const Serverless = require('serverless/lib/Serverless')
+const AwsProvider = require('serverless/lib/plugins/aws/provider/awsProvider')
+const ServerlessApigatewayServiceProxy = require('./../../index')
+
+chai.use(require('chai-as-promised'))
+const expect = require('chai').expect
+
+describe('#compileIamRoleToSns()', () => {
+  let serverless
+  let serverlessApigatewayServiceProxy
+
+  beforeEach(() => {
+    serverless = new Serverless()
+    serverless.servicePath = true
+    serverless.service.service = 'apigw-service-proxy'
+    const options = {
+      stage: 'dev',
+      region: 'us-east-1'
+    }
+    serverless.setProvider('aws', new AwsProvider(serverless))
+    serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} }
+    serverlessApigatewayServiceProxy = new ServerlessApigatewayServiceProxy(serverless, options)
+  })
+
+  it('should create corresponding resources', async () => {
+    serverlessApigatewayServiceProxy.serverless.service.custom = {
+      apiGatewayServiceProxies: [
+        {
+          sns: {
+            path: '/sns1',
+            method: 'post',
+            topicName: { 'Fn::GetAtt': ['SNSTopic1', 'TopicName'] }
+          }
+        },
+        {
+          sns: {
+            path: '/sns2',
+            method: 'post',
+            topicName: { 'Fn::GetAtt': ['SNSTopic2', 'TopicName'] }
+          }
+        },
+        {
+          kinesis: {
+            path: '/kinesis',
+            method: 'post',
+            streamName: { Ref: 'KinesisStream' }
+          }
+        },
+        {
+          sqs: {
+            path: '/sqs',
+            method: 'post',
+            queueName: { 'Fn::GetAtt': ['SQSQueue', 'QueueName'] }
+          }
+        }
+      ]
+    }
+
+    serverlessApigatewayServiceProxy.compileIamRoleToSns()
+
+    expect(serverless.service.provider.compiledCloudFormationTemplate.Resources).to.deep.equal({
+      ApigatewayToSnsRole: {
+        Type: 'AWS::IAM::Role',
+        Properties: {
+          AssumeRolePolicyDocument: {
+            Version: '2012-10-17',
+            Statement: [
+              {
+                Effect: 'Allow',
+                Principal: {
+                  Service: 'apigateway.amazonaws.com'
+                },
+                Action: 'sts:AssumeRole'
+              }
+            ]
+          },
+          Policies: [
+            {
+              PolicyName: 'apigatewaytosns',
+              PolicyDocument: {
+                Version: '2012-10-17',
+                Statement: [
+                  {
+                    Effect: 'Allow',
+                    Action: ['logs:CreateLogGroup', 'logs:CreateLogStream', 'logs:PutLogEvents'],
+                    Resource: '*'
+                  },
+                  {
+                    Effect: 'Allow',
+                    Action: ['sns:Publish'],
+                    Resource: [
+                      {
+                        'Fn::Sub': [
+                          'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
+                          { topicName: { 'Fn::GetAtt': ['SNSTopic1', 'TopicName'] } }
+                        ]
+                      },
+                      {
+                        'Fn::Sub': [
+                          'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
+                          { topicName: { 'Fn::GetAtt': ['SNSTopic2', 'TopicName'] } }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    })
+  })
+
+  it('should not create corresponding resources when other proxies are given', async () => {
+    serverlessApigatewayServiceProxy.serverless.service.custom = {
+      apiGatewayServiceProxies: [
+        {
+          kinesis: {
+            path: '/kinesis',
+            method: 'post'
+          }
+        }
+      ]
+    }
+
+    serverlessApigatewayServiceProxy.compileIamRoleToSns()
+
+    expect(serverless.service.provider.compiledCloudFormationTemplate.Resources).to.be.empty
+  })
+})

--- a/lib/package/sns/compileMethodsToSns.js
+++ b/lib/package/sns/compileMethodsToSns.js
@@ -1,0 +1,147 @@
+'use strict'
+
+const _ = require('lodash')
+
+module.exports = {
+  compileMethodsToSns() {
+    this.validated.events.forEach((event) => {
+      if (event.serviceName == 'sns') {
+        const resourceId = this.getResourceId(event.http.path)
+        const resourceName = this.getResourceName(event.http.path)
+
+        const template = {
+          Type: 'AWS::ApiGateway::Method',
+          Properties: {
+            HttpMethod: event.http.method.toUpperCase(),
+            RequestParameters: {},
+            AuthorizationType: event.http.auth.authorizationType,
+            AuthorizationScopes: event.http.auth.authorizationScopes,
+            AuthorizerId: event.http.auth.authorizerId,
+            ApiKeyRequired: Boolean(event.http.private),
+            ResourceId: resourceId,
+            RestApiId: this.provider.getApiGatewayRestApiId()
+          }
+        }
+
+        _.merge(
+          template,
+          this.getSnsMethodIntegration(event.http),
+          this.getMethodResponses(event.http)
+        )
+
+        const methodLogicalId = this.provider.naming.getMethodLogicalId(
+          resourceName,
+          event.http.method
+        )
+
+        this.apiGatewayMethodLogicalIds.push(methodLogicalId)
+
+        _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
+          [methodLogicalId]: template
+        })
+      }
+    })
+  },
+
+  getSnsMethodIntegration(http) {
+    const integration = {
+      IntegrationHttpMethod: 'POST',
+      Type: 'AWS',
+      Credentials: {
+        'Fn::GetAtt': ['ApigatewayToSnsRole', 'Arn']
+      },
+      Uri: {
+        'Fn::Join': [
+          '',
+          [
+            'arn:aws:apigateway:',
+            {
+              Ref: 'AWS::Region'
+            },
+            ':sns:path//'
+          ]
+        ]
+      },
+      PassthroughBehavior: 'NEVER',
+      RequestParameters: {
+        'integration.request.header.Content-Type': "'application/x-www-form-urlencoded'"
+      },
+      RequestTemplates: this.getSnsIntegrationRequestTemplates(http)
+    }
+
+    const integrationResponse = {
+      IntegrationResponses: [
+        {
+          StatusCode: 200,
+          SelectionPattern: 200,
+          ResponseParameters: {},
+          ResponseTemplates: {}
+        },
+        {
+          StatusCode: 400,
+          SelectionPattern: 400,
+          ResponseParameters: {},
+          ResponseTemplates: {}
+        },
+        {
+          StatusCode: 500,
+          SelectionPattern: 500,
+          ResponseParameters: {},
+          ResponseTemplates: {}
+        }
+      ]
+    }
+
+    if (http && http.cors) {
+      let origin = http.cors.origin
+      if (http.cors.origins && http.cors.origins.length) {
+        origin = http.cors.origins.join(',')
+      }
+
+      integrationResponse.IntegrationResponses.forEach(async (val, i) => {
+        integrationResponse.IntegrationResponses[i].ResponseParameters = {
+          'method.response.header.Access-Control-Allow-Origin': `'${origin}'`
+        }
+      })
+    }
+
+    _.merge(integration, integrationResponse)
+
+    return {
+      Properties: {
+        Integration: integration
+      }
+    }
+  },
+
+  getSnsIntegrationRequestTemplates(http) {
+    const defaultRequestTemplates = this.getDefaultSnsRequestTemplates(http)
+    return Object.assign(defaultRequestTemplates, _.get(http, ['request', 'template']))
+  },
+
+  getDefaultSnsRequestTemplates(http) {
+    return {
+      'application/json': this.buildDefaultSnsRequestTemplate(http),
+      'application/x-www-form-urlencoded': this.buildDefaultSnsRequestTemplate(http)
+    }
+  },
+
+  buildDefaultSnsRequestTemplate(http) {
+    const { topicName } = http
+
+    const topicArn = {
+      'Fn::Sub': ['arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${topicName}', { topicName }]
+    }
+
+    return {
+      'Fn::Join': [
+        '',
+        [
+          "Action=Publish&Message=$util.urlEncode($input.body)&TopicArn=$util.urlEncode('",
+          topicArn,
+          "')"
+        ]
+      ]
+    }
+  }
+}

--- a/lib/package/sns/compileMethodsToSns.js
+++ b/lib/package/sns/compileMethodsToSns.js
@@ -51,16 +51,7 @@ module.exports = {
         'Fn::GetAtt': ['ApigatewayToSnsRole', 'Arn']
       },
       Uri: {
-        'Fn::Join': [
-          '',
-          [
-            'arn:aws:apigateway:',
-            {
-              Ref: 'AWS::Region'
-            },
-            ':sns:path//'
-          ]
-        ]
+        'Fn::Sub': 'arn:aws:apigateway:${AWS::Region}:sns:path//'
       },
       PassthroughBehavior: 'NEVER',
       RequestParameters: {

--- a/lib/package/sns/compileMethodsToSns.test.js
+++ b/lib/package/sns/compileMethodsToSns.test.js
@@ -70,7 +70,7 @@ describe('#compileMethodsToSns()', () => {
             Type: 'AWS',
             Credentials: { 'Fn::GetAtt': ['ApigatewayToSnsRole', 'Arn'] },
             Uri: {
-              'Fn::Join': ['', ['arn:aws:apigateway:', { Ref: 'AWS::Region' }, ':sns:path//']]
+              'Fn::Sub': 'arn:aws:apigateway:${AWS::Region}:sns:path//'
             },
             PassthroughBehavior: 'NEVER',
             RequestParameters: {
@@ -196,7 +196,7 @@ describe('#compileMethodsToSns()', () => {
             Type: 'AWS',
             Credentials: { 'Fn::GetAtt': ['ApigatewayToSnsRole', 'Arn'] },
             Uri: {
-              'Fn::Join': ['', ['arn:aws:apigateway:', { Ref: 'AWS::Region' }, ':sns:path//']]
+              'Fn::Sub': 'arn:aws:apigateway:${AWS::Region}:sns:path//'
             },
             PassthroughBehavior: 'NEVER',
             RequestParameters: {
@@ -465,7 +465,7 @@ describe('#compileMethodsToSns()', () => {
             Type: 'AWS',
             Credentials: { 'Fn::GetAtt': ['ApigatewayToSnsRole', 'Arn'] },
             Uri: {
-              'Fn::Join': ['', ['arn:aws:apigateway:', { Ref: 'AWS::Region' }, ':sns:path//']]
+              'Fn::Sub': 'arn:aws:apigateway:${AWS::Region}:sns:path//'
             },
             PassthroughBehavior: 'NEVER',
             RequestParameters: {
@@ -578,7 +578,7 @@ describe('#compileMethodsToSns()', () => {
             Type: 'AWS',
             Credentials: { 'Fn::GetAtt': ['ApigatewayToSnsRole', 'Arn'] },
             Uri: {
-              'Fn::Join': ['', ['arn:aws:apigateway:', { Ref: 'AWS::Region' }, ':sns:path//']]
+              'Fn::Sub': 'arn:aws:apigateway:${AWS::Region}:sns:path//'
             },
             PassthroughBehavior: 'NEVER',
             RequestParameters: {

--- a/lib/package/sns/compileMethodsToSns.test.js
+++ b/lib/package/sns/compileMethodsToSns.test.js
@@ -8,7 +8,7 @@ const ServerlessApigatewayServiceProxy = require('./../../index')
 chai.use(require('chai-as-promised'))
 const expect = require('chai').expect
 
-describe('#compileMethodsToKinesis()', () => {
+describe('#compileMethodsToSns()', () => {
   let serverless
   let serverlessApigatewayServiceProxy
 
@@ -27,14 +27,14 @@ describe('#compileMethodsToKinesis()', () => {
     serverlessApigatewayServiceProxy = new ServerlessApigatewayServiceProxy(serverless, options)
   })
 
-  it('should create corresponding resources when kinesis proxies are given', async () => {
+  it('should create corresponding resources when sns proxies are given', async () => {
     serverlessApigatewayServiceProxy.validated = {
       events: [
         {
-          serviceName: 'kinesis',
+          serviceName: 'sns',
           http: {
-            streamName: 'myStream',
-            path: 'kinesis',
+            topicName: 'myTopic',
+            path: 'sns',
             method: 'post',
             auth: {
               authorizationType: 'NONE'
@@ -45,16 +45,16 @@ describe('#compileMethodsToKinesis()', () => {
     }
     serverlessApigatewayServiceProxy.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi'
     serverlessApigatewayServiceProxy.apiGatewayResources = {
-      kinesis: {
-        name: 'kinesis',
-        resourceLogicalId: 'ApiGatewayResourceKinesis'
+      sns: {
+        name: 'Sns',
+        resourceLogicalId: 'ApiGatewayResourceSns'
       }
     }
 
-    await expect(serverlessApigatewayServiceProxy.compileMethodsToKinesis()).to.be.fulfilled
+    serverlessApigatewayServiceProxy.compileMethodsToSns()
 
     expect(serverless.service.provider.compiledCloudFormationTemplate.Resources).to.deep.equal({
-      ApiGatewayMethodkinesisPost: {
+      ApiGatewayMethodSnsPost: {
         Type: 'AWS::ApiGateway::Method',
         Properties: {
           HttpMethod: 'POST',
@@ -63,31 +63,32 @@ describe('#compileMethodsToKinesis()', () => {
           AuthorizationScopes: undefined,
           AuthorizerId: undefined,
           ApiKeyRequired: false,
-          ResourceId: { Ref: 'ApiGatewayResourceKinesis' },
+          ResourceId: { Ref: 'ApiGatewayResourceSns' },
           RestApiId: { Ref: 'ApiGatewayRestApi' },
           Integration: {
             IntegrationHttpMethod: 'POST',
             Type: 'AWS',
-            Credentials: { 'Fn::GetAtt': ['ApigatewayToKinesisRole', 'Arn'] },
+            Credentials: { 'Fn::GetAtt': ['ApigatewayToSnsRole', 'Arn'] },
             Uri: {
-              'Fn::Join': [
-                '',
-                ['arn:aws:apigateway:', { Ref: 'AWS::Region' }, ':kinesis:action/PutRecord']
-              ]
+              'Fn::Join': ['', ['arn:aws:apigateway:', { Ref: 'AWS::Region' }, ':sns:path//']]
             },
             PassthroughBehavior: 'NEVER',
+            RequestParameters: {
+              'integration.request.header.Content-Type': "'application/x-www-form-urlencoded'"
+            },
             RequestTemplates: {
               'application/json': {
                 'Fn::Join': [
                   '',
                   [
-                    '{',
-                    '"StreamName": "',
-                    '"myStream"',
-                    '",',
-                    '"Data": "$util.base64Encode($input.body)",',
-                    '"PartitionKey": "$context.requestId"',
-                    '}'
+                    "Action=Publish&Message=$util.urlEncode($input.body)&TopicArn=$util.urlEncode('",
+                    {
+                      'Fn::Sub': [
+                        'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
+                        { topicName: 'myTopic' }
+                      ]
+                    },
+                    "')"
                   ]
                 ]
               },
@@ -95,13 +96,14 @@ describe('#compileMethodsToKinesis()', () => {
                 'Fn::Join': [
                   '',
                   [
-                    '{',
-                    '"StreamName": "',
-                    '"myStream"',
-                    '",',
-                    '"Data": "$util.base64Encode($input.body)",',
-                    '"PartitionKey": "$context.requestId"',
-                    '}'
+                    "Action=Publish&Message=$util.urlEncode($input.body)&TopicArn=$util.urlEncode('",
+                    {
+                      'Fn::Sub': [
+                        'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
+                        { topicName: 'myTopic' }
+                      ]
+                    },
+                    "')"
                   ]
                 ]
               }
@@ -137,14 +139,14 @@ describe('#compileMethodsToKinesis()', () => {
     })
   })
 
-  it('should create corresponding resources when kinesis proxies are given with cors', async () => {
+  it('should create corresponding resources when sns proxies are given with cors', async () => {
     serverlessApigatewayServiceProxy.validated = {
       events: [
         {
-          serviceName: 'kinesis',
+          serviceName: 'sns',
           http: {
-            streamName: 'myStream',
-            path: 'kinesis',
+            topicName: 'myTopic',
+            path: 'sns',
             method: 'post',
             auth: {
               authorizationType: 'NONE'
@@ -169,16 +171,16 @@ describe('#compileMethodsToKinesis()', () => {
     }
     serverlessApigatewayServiceProxy.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi'
     serverlessApigatewayServiceProxy.apiGatewayResources = {
-      kinesis: {
-        name: 'kinesis',
-        resourceLogicalId: 'ApiGatewayResourceKinesis'
+      sns: {
+        name: 'Sns',
+        resourceLogicalId: 'ApiGatewayResourceSns'
       }
     }
 
-    await expect(serverlessApigatewayServiceProxy.compileMethodsToKinesis()).to.be.fulfilled
+    serverlessApigatewayServiceProxy.compileMethodsToSns()
 
     expect(serverless.service.provider.compiledCloudFormationTemplate.Resources).to.deep.equal({
-      ApiGatewayMethodkinesisPost: {
+      ApiGatewayMethodSnsPost: {
         Type: 'AWS::ApiGateway::Method',
         Properties: {
           HttpMethod: 'POST',
@@ -187,31 +189,32 @@ describe('#compileMethodsToKinesis()', () => {
           AuthorizerId: undefined,
           AuthorizationScopes: undefined,
           ApiKeyRequired: false,
-          ResourceId: { Ref: 'ApiGatewayResourceKinesis' },
+          ResourceId: { Ref: 'ApiGatewayResourceSns' },
           RestApiId: { Ref: 'ApiGatewayRestApi' },
           Integration: {
             IntegrationHttpMethod: 'POST',
             Type: 'AWS',
-            Credentials: { 'Fn::GetAtt': ['ApigatewayToKinesisRole', 'Arn'] },
+            Credentials: { 'Fn::GetAtt': ['ApigatewayToSnsRole', 'Arn'] },
             Uri: {
-              'Fn::Join': [
-                '',
-                ['arn:aws:apigateway:', { Ref: 'AWS::Region' }, ':kinesis:action/PutRecord']
-              ]
+              'Fn::Join': ['', ['arn:aws:apigateway:', { Ref: 'AWS::Region' }, ':sns:path//']]
             },
             PassthroughBehavior: 'NEVER',
+            RequestParameters: {
+              'integration.request.header.Content-Type': "'application/x-www-form-urlencoded'"
+            },
             RequestTemplates: {
               'application/json': {
                 'Fn::Join': [
                   '',
                   [
-                    '{',
-                    '"StreamName": "',
-                    '"myStream"',
-                    '",',
-                    '"Data": "$util.base64Encode($input.body)",',
-                    '"PartitionKey": "$context.requestId"',
-                    '}'
+                    "Action=Publish&Message=$util.urlEncode($input.body)&TopicArn=$util.urlEncode('",
+                    {
+                      'Fn::Sub': [
+                        'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
+                        { topicName: 'myTopic' }
+                      ]
+                    },
+                    "')"
                   ]
                 ]
               },
@@ -219,13 +222,14 @@ describe('#compileMethodsToKinesis()', () => {
                 'Fn::Join': [
                   '',
                   [
-                    '{',
-                    '"StreamName": "',
-                    '"myStream"',
-                    '",',
-                    '"Data": "$util.base64Encode($input.body)",',
-                    '"PartitionKey": "$context.requestId"',
-                    '}'
+                    "Action=Publish&Message=$util.urlEncode($input.body)&TopicArn=$util.urlEncode('",
+                    {
+                      'Fn::Sub': [
+                        'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
+                        { topicName: 'myTopic' }
+                      ]
+                    },
+                    "')"
                   ]
                 ]
               }
@@ -277,6 +281,7 @@ describe('#compileMethodsToKinesis()', () => {
     const httpWithoutRequestTemplate = {
       path: 'foo/bar1',
       method: 'post',
+      topicName: 'myTopic',
       request: {
         template: {
           'application/x-www-form-urlencoded': 'custom template'
@@ -287,7 +292,7 @@ describe('#compileMethodsToKinesis()', () => {
       }
     }
 
-    const resource = await serverlessApigatewayServiceProxy.getKinesisMethodIntegration(
+    const resource = serverlessApigatewayServiceProxy.getSnsMethodIntegration(
       httpWithoutRequestTemplate
     )
 
@@ -296,173 +301,14 @@ describe('#compileMethodsToKinesis()', () => {
     ).to.be.deep.equal([
       '',
       [
-        '{',
-        '"StreamName": "',
-        '"undefined"',
-        '",',
-        '"Data": "$util.base64Encode($input.body)",',
-        '"PartitionKey": "$context.requestId"',
-        '}'
-      ]
-    ])
-  })
-
-  it('should set path parameter to partitionkey when pathParam is given', async () => {
-    const httpWithoutRequestTemplate = {
-      path: 'foo/{key1}',
-      method: 'post',
-      partitionKey: {
-        pathParam: 'key1'
-      },
-      streamName: 'testStream',
-      auth: {
-        authorizationType: 'NONE'
-      }
-    }
-
-    const resource = await serverlessApigatewayServiceProxy.getKinesisMethodIntegration(
-      httpWithoutRequestTemplate
-    )
-
-    expect(
-      resource.Properties.Integration.RequestTemplates['application/json']['Fn::Join']
-    ).to.be.deep.equal([
-      '',
-      [
-        '{',
-        '"StreamName": "',
-        '"testStream"',
-        '",',
-        '"Data": "$util.base64Encode($input.body)",',
-        '"PartitionKey": "$input.params().path.key1"',
-        '}'
-      ]
-    ])
-  })
-
-  it('should set body parameter to partitionkey when bodyParam is given', async () => {
-    const httpWithoutRequestTemplate = {
-      path: 'foo',
-      method: 'post',
-      partitionKey: {
-        bodyParam: 'data.messageId'
-      },
-      streamName: 'testStream',
-      auth: {
-        authorizationType: 'NONE'
-      }
-    }
-
-    const resource = await serverlessApigatewayServiceProxy.getKinesisMethodIntegration(
-      httpWithoutRequestTemplate
-    )
-
-    expect(
-      resource.Properties.Integration.RequestTemplates['application/json']['Fn::Join']
-    ).to.be.deep.equal([
-      '',
-      [
-        '{',
-        '"StreamName": "',
-        '"testStream"',
-        '",',
-        '"Data": "$util.base64Encode($input.body)",',
-        '"PartitionKey": "$util.parseJson($input.body).data.messageId"',
-        '}'
-      ]
-    ])
-  })
-
-  it('should set querystring parameter to partitionkey when queryStringParam is given', async () => {
-    const httpWithoutRequestTemplate = {
-      path: 'foo?key=xxxxx',
-      method: 'post',
-      partitionKey: {
-        queryStringParam: 'key'
-      },
-      streamName: 'testStream',
-      auth: {
-        authorizationType: 'NONE'
-      }
-    }
-
-    const resource = await serverlessApigatewayServiceProxy.getKinesisMethodIntegration(
-      httpWithoutRequestTemplate
-    )
-
-    expect(
-      resource.Properties.Integration.RequestTemplates['application/json']['Fn::Join']
-    ).to.be.deep.equal([
-      '',
-      [
-        '{',
-        '"StreamName": "',
-        '"testStream"',
-        '",',
-        '"Data": "$util.base64Encode($input.body)",',
-        '"PartitionKey": "$input.params().querystring.key"',
-        '}'
-      ]
-    ])
-  })
-
-  it('should set apigateway requestid to partitionkey when no one is given', async () => {
-    const httpWithoutRequestTemplate = {
-      path: 'foo',
-      method: 'post',
-      streamName: 'testStream',
-      auth: {
-        authorizationType: 'NONE'
-      }
-    }
-
-    const resource = await serverlessApigatewayServiceProxy.getKinesisMethodIntegration(
-      httpWithoutRequestTemplate
-    )
-
-    expect(
-      resource.Properties.Integration.RequestTemplates['application/json']['Fn::Join']
-    ).to.be.deep.equal([
-      '',
-      [
-        '{',
-        '"StreamName": "',
-        '"testStream"',
-        '",',
-        '"Data": "$util.base64Encode($input.body)",',
-        '"PartitionKey": "$context.requestId"',
-        '}'
-      ]
-    ])
-  })
-
-  it('should set specified value to partitionkey when the param is hardcorded', async () => {
-    const httpWithoutRequestTemplate = {
-      path: 'foo',
-      method: 'post',
-      streamName: 'testStream',
-      partitionKey: 'mykey',
-      auth: {
-        authorizationType: 'NONE'
-      }
-    }
-
-    const resource = await serverlessApigatewayServiceProxy.getKinesisMethodIntegration(
-      httpWithoutRequestTemplate
-    )
-
-    expect(
-      resource.Properties.Integration.RequestTemplates['application/json']['Fn::Join']
-    ).to.be.deep.equal([
-      '',
-      [
-        '{',
-        '"StreamName": "',
-        '"testStream"',
-        '",',
-        '"Data": "$util.base64Encode($input.body)",',
-        '"PartitionKey": "mykey"',
-        '}'
+        "Action=Publish&Message=$util.urlEncode($input.body)&TopicArn=$util.urlEncode('",
+        {
+          'Fn::Sub': [
+            'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
+            { topicName: 'myTopic' }
+          ]
+        },
+        "')"
       ]
     ])
   })
@@ -471,6 +317,7 @@ describe('#compileMethodsToKinesis()', () => {
     const httpWithRequestTemplate = {
       path: 'foo/bar1',
       method: 'post',
+      topicName: 'myTopic',
       request: {
         template: {
           'application/json': 'custom template'
@@ -480,7 +327,7 @@ describe('#compileMethodsToKinesis()', () => {
         authorizationType: 'NONE'
       }
     }
-    const resource = await serverlessApigatewayServiceProxy.getKinesisMethodIntegration(
+    const resource = serverlessApigatewayServiceProxy.getSnsMethodIntegration(
       httpWithRequestTemplate
     )
     expect(resource.Properties.Integration.RequestTemplates['application/json']).to.be.equal(
@@ -492,6 +339,7 @@ describe('#compileMethodsToKinesis()', () => {
     const httpWithoutRequestTemplate = {
       path: 'foo/bar1',
       method: 'post',
+      topicName: 'myTopic',
       request: {
         template: {
           'application/json': 'custom template'
@@ -501,7 +349,7 @@ describe('#compileMethodsToKinesis()', () => {
         authorizationType: 'NONE'
       }
     }
-    const resource = await serverlessApigatewayServiceProxy.getKinesisMethodIntegration(
+    const resource = serverlessApigatewayServiceProxy.getSnsMethodIntegration(
       httpWithoutRequestTemplate
     )
     expect(
@@ -511,13 +359,14 @@ describe('#compileMethodsToKinesis()', () => {
     ).to.be.deep.equal([
       '',
       [
-        '{',
-        '"StreamName": "',
-        '"undefined"',
-        '",',
-        '"Data": "$util.base64Encode($input.body)",',
-        '"PartitionKey": "$context.requestId"',
-        '}'
+        "Action=Publish&Message=$util.urlEncode($input.body)&TopicArn=$util.urlEncode('",
+        {
+          'Fn::Sub': [
+            'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
+            { topicName: 'myTopic' }
+          ]
+        },
+        "')"
       ]
     ])
   })
@@ -526,6 +375,7 @@ describe('#compileMethodsToKinesis()', () => {
     const httpWithRequestTemplate = {
       path: 'foo/bar1',
       method: 'post',
+      topicName: 'myTopic',
       request: {
         template: {
           'application/x-www-form-urlencoded': 'custom template'
@@ -535,7 +385,7 @@ describe('#compileMethodsToKinesis()', () => {
         authorizationType: 'NONE'
       }
     }
-    const resource = await serverlessApigatewayServiceProxy.getKinesisMethodIntegration(
+    const resource = serverlessApigatewayServiceProxy.getSnsMethodIntegration(
       httpWithRequestTemplate
     )
     expect(
@@ -561,13 +411,13 @@ describe('#compileMethodsToKinesis()', () => {
     }
     serverlessApigatewayServiceProxy.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi'
     serverlessApigatewayServiceProxy.apiGatewayResources = {
-      kinesis: {
-        name: 'kinesis',
-        resourceLogicalId: 'ApiGatewayResourceKinesis'
+      sns: {
+        name: 'Sns',
+        resourceLogicalId: 'ApiGatewayResourceSns'
       }
     }
 
-    await expect(serverlessApigatewayServiceProxy.compileMethodsToKinesis()).to.be.fulfilled
+    serverlessApigatewayServiceProxy.compileMethodsToSns()
     expect(serverless.service.provider.compiledCloudFormationTemplate.Resources).to.be.empty
   })
 
@@ -575,10 +425,10 @@ describe('#compileMethodsToKinesis()', () => {
     serverlessApigatewayServiceProxy.validated = {
       events: [
         {
-          serviceName: 'kinesis',
+          serviceName: 'sns',
           http: {
-            streamName: 'myStream',
-            path: 'kinesis',
+            topicName: 'myTopic',
+            path: 'sns',
             method: 'post',
             auth: {
               authorizationType: 'CUSTOM',
@@ -590,16 +440,16 @@ describe('#compileMethodsToKinesis()', () => {
     }
     serverlessApigatewayServiceProxy.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi'
     serverlessApigatewayServiceProxy.apiGatewayResources = {
-      kinesis: {
-        name: 'kinesis',
-        resourceLogicalId: 'ApiGatewayResourceKinesis'
+      sns: {
+        name: 'Sns',
+        resourceLogicalId: 'ApiGatewayResourceSns'
       }
     }
 
-    await expect(serverlessApigatewayServiceProxy.compileMethodsToKinesis()).to.be.fulfilled
+    serverlessApigatewayServiceProxy.compileMethodsToSns()
 
     expect(serverless.service.provider.compiledCloudFormationTemplate.Resources).to.deep.equal({
-      ApiGatewayMethodkinesisPost: {
+      ApiGatewayMethodSnsPost: {
         Type: 'AWS::ApiGateway::Method',
         Properties: {
           HttpMethod: 'POST',
@@ -608,31 +458,32 @@ describe('#compileMethodsToKinesis()', () => {
           AuthorizationScopes: undefined,
           AuthorizerId: { Ref: 'AuthorizerLogicalId' },
           ApiKeyRequired: false,
-          ResourceId: { Ref: 'ApiGatewayResourceKinesis' },
+          ResourceId: { Ref: 'ApiGatewayResourceSns' },
           RestApiId: { Ref: 'ApiGatewayRestApi' },
           Integration: {
             IntegrationHttpMethod: 'POST',
             Type: 'AWS',
-            Credentials: { 'Fn::GetAtt': ['ApigatewayToKinesisRole', 'Arn'] },
+            Credentials: { 'Fn::GetAtt': ['ApigatewayToSnsRole', 'Arn'] },
             Uri: {
-              'Fn::Join': [
-                '',
-                ['arn:aws:apigateway:', { Ref: 'AWS::Region' }, ':kinesis:action/PutRecord']
-              ]
+              'Fn::Join': ['', ['arn:aws:apigateway:', { Ref: 'AWS::Region' }, ':sns:path//']]
             },
             PassthroughBehavior: 'NEVER',
+            RequestParameters: {
+              'integration.request.header.Content-Type': "'application/x-www-form-urlencoded'"
+            },
             RequestTemplates: {
               'application/json': {
                 'Fn::Join': [
                   '',
                   [
-                    '{',
-                    '"StreamName": "',
-                    '"myStream"',
-                    '",',
-                    '"Data": "$util.base64Encode($input.body)",',
-                    '"PartitionKey": "$context.requestId"',
-                    '}'
+                    "Action=Publish&Message=$util.urlEncode($input.body)&TopicArn=$util.urlEncode('",
+                    {
+                      'Fn::Sub': [
+                        'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
+                        { topicName: 'myTopic' }
+                      ]
+                    },
+                    "')"
                   ]
                 ]
               },
@@ -640,13 +491,14 @@ describe('#compileMethodsToKinesis()', () => {
                 'Fn::Join': [
                   '',
                   [
-                    '{',
-                    '"StreamName": "',
-                    '"myStream"',
-                    '",',
-                    '"Data": "$util.base64Encode($input.body)",',
-                    '"PartitionKey": "$context.requestId"',
-                    '}'
+                    "Action=Publish&Message=$util.urlEncode($input.body)&TopicArn=$util.urlEncode('",
+                    {
+                      'Fn::Sub': [
+                        'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
+                        { topicName: 'myTopic' }
+                      ]
+                    },
+                    "')"
                   ]
                 ]
               }
@@ -686,10 +538,10 @@ describe('#compileMethodsToKinesis()', () => {
     serverlessApigatewayServiceProxy.validated = {
       events: [
         {
-          serviceName: 'kinesis',
+          serviceName: 'sns',
           http: {
-            streamName: 'myStream',
-            path: 'kinesis',
+            topicName: 'myTopic',
+            path: 'sns',
             method: 'post',
             auth: {
               authorizationType: 'COGNITO_USER_POOLS',
@@ -701,16 +553,16 @@ describe('#compileMethodsToKinesis()', () => {
     }
     serverlessApigatewayServiceProxy.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi'
     serverlessApigatewayServiceProxy.apiGatewayResources = {
-      kinesis: {
-        name: 'kinesis',
-        resourceLogicalId: 'ApiGatewayResourceKinesis'
+      sns: {
+        name: 'Sns',
+        resourceLogicalId: 'ApiGatewayResourceSns'
       }
     }
 
-    await expect(serverlessApigatewayServiceProxy.compileMethodsToKinesis()).to.be.fulfilled
+    serverlessApigatewayServiceProxy.compileMethodsToSns()
 
     expect(serverless.service.provider.compiledCloudFormationTemplate.Resources).to.deep.equal({
-      ApiGatewayMethodkinesisPost: {
+      ApiGatewayMethodSnsPost: {
         Type: 'AWS::ApiGateway::Method',
         Properties: {
           HttpMethod: 'POST',
@@ -719,31 +571,32 @@ describe('#compileMethodsToKinesis()', () => {
           AuthorizationScopes: undefined,
           AuthorizerId: undefined,
           ApiKeyRequired: false,
-          ResourceId: { Ref: 'ApiGatewayResourceKinesis' },
+          ResourceId: { Ref: 'ApiGatewayResourceSns' },
           RestApiId: { Ref: 'ApiGatewayRestApi' },
           Integration: {
             IntegrationHttpMethod: 'POST',
             Type: 'AWS',
-            Credentials: { 'Fn::GetAtt': ['ApigatewayToKinesisRole', 'Arn'] },
+            Credentials: { 'Fn::GetAtt': ['ApigatewayToSnsRole', 'Arn'] },
             Uri: {
-              'Fn::Join': [
-                '',
-                ['arn:aws:apigateway:', { Ref: 'AWS::Region' }, ':kinesis:action/PutRecord']
-              ]
+              'Fn::Join': ['', ['arn:aws:apigateway:', { Ref: 'AWS::Region' }, ':sns:path//']]
             },
             PassthroughBehavior: 'NEVER',
+            RequestParameters: {
+              'integration.request.header.Content-Type': "'application/x-www-form-urlencoded'"
+            },
             RequestTemplates: {
               'application/json': {
                 'Fn::Join': [
                   '',
                   [
-                    '{',
-                    '"StreamName": "',
-                    '"myStream"',
-                    '",',
-                    '"Data": "$util.base64Encode($input.body)",',
-                    '"PartitionKey": "$context.requestId"',
-                    '}'
+                    "Action=Publish&Message=$util.urlEncode($input.body)&TopicArn=$util.urlEncode('",
+                    {
+                      'Fn::Sub': [
+                        'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
+                        { topicName: 'myTopic' }
+                      ]
+                    },
+                    "')"
                   ]
                 ]
               },
@@ -751,13 +604,14 @@ describe('#compileMethodsToKinesis()', () => {
                 'Fn::Join': [
                   '',
                   [
-                    '{',
-                    '"StreamName": "',
-                    '"myStream"',
-                    '",',
-                    '"Data": "$util.base64Encode($input.body)",',
-                    '"PartitionKey": "$context.requestId"',
-                    '}'
+                    "Action=Publish&Message=$util.urlEncode($input.body)&TopicArn=$util.urlEncode('",
+                    {
+                      'Fn::Sub': [
+                        'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
+                        { topicName: 'myTopic' }
+                      ]
+                    },
+                    "')"
                   ]
                 ]
               }

--- a/lib/package/sns/compileSnsServiceProxy.js
+++ b/lib/package/sns/compileSnsServiceProxy.js
@@ -1,0 +1,8 @@
+'use strict'
+module.exports = {
+  async compileSnsServiceProxy() {
+    this.validateSnsServiceProxy()
+    this.compileIamRoleToSns()
+    this.compileMethodsToSns()
+  }
+}

--- a/lib/package/sns/schema.js
+++ b/lib/package/sns/schema.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const Joi = require('@hapi/joi')
+
+// topic name must be a string or a an object structured as { 'Fn::GetAtt': ['SNSLogicalId', 'TopicName'] }
+const topicName = Joi.alternatives().try([
+  Joi.object({
+    'Fn::GetAtt': Joi.array()
+      .length(2)
+      .ordered(
+        Joi.string().required(),
+        Joi.string()
+          .valid('TopicName')
+          .required()
+      )
+      .required()
+  }),
+  Joi.string()
+])
+
+const schema = Joi.object().keys({
+  topicName: topicName.required()
+})
+
+module.exports = schema

--- a/lib/package/sns/validateSnsServiceProxy.js
+++ b/lib/package/sns/validateSnsServiceProxy.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const Joi = require('@hapi/joi')
+const schema = require('./schema')
+
+module.exports = {
+  validateSnsServiceProxy() {
+    this.validated.events.forEach((serviceProxy) => {
+      if (serviceProxy.serviceName == 'sns') {
+        const { error } = Joi.validate(serviceProxy.http, schema, { allowUnknown: true })
+
+        if (error) {
+          throw new this.serverless.classes.Error(error)
+        }
+      }
+    })
+  }
+}

--- a/lib/package/sns/validateSnsServiceProxy.test.js
+++ b/lib/package/sns/validateSnsServiceProxy.test.js
@@ -25,7 +25,7 @@ describe('#validateSnsServiceProxy()', () => {
     serverlessApigatewayServiceProxy = new ServerlessApigatewayServiceProxy(serverless, options)
   })
 
-  it('should validate the "topicName" property existence', async () => {
+  it('should throw error if the "topicName" property doesn\'t exist', async () => {
     serverlessApigatewayServiceProxy.validated = {
       events: [
         {
@@ -43,7 +43,7 @@ describe('#validateSnsServiceProxy()', () => {
     )
   })
 
-  it('should validate the "topicName" property if it is string or AWS intrinsic function', async () => {
+  it('should throw error if the "topicName" property is not a string or an AWS intrinsic function', async () => {
     serverlessApigatewayServiceProxy.validated = {
       events: [
         {
@@ -62,7 +62,7 @@ describe('#validateSnsServiceProxy()', () => {
     )
   })
 
-  it('should validate the "topicName" property that AWS intrinsic function is correct syntax', async () => {
+  it('should throw error if the "topicName" property is missing the AWS intrinsic function "Fn::GetAtt"', async () => {
     serverlessApigatewayServiceProxy.validated = {
       events: [
         {
@@ -81,7 +81,7 @@ describe('#validateSnsServiceProxy()', () => {
     )
   })
 
-  it('should validate the "topicName" property if wrong AWS intrinsic function is specified', async () => {
+  it('should throw error if the "topicName" property is an intrinsic function "Fn::GetAtt" but specifies a property other than TopicName', async () => {
     serverlessApigatewayServiceProxy.validated = {
       events: [
         {

--- a/lib/package/sns/validateSnsServiceProxy.test.js
+++ b/lib/package/sns/validateSnsServiceProxy.test.js
@@ -1,0 +1,136 @@
+'use strict'
+
+const chai = require('chai')
+const Serverless = require('serverless/lib/Serverless')
+const AwsProvider = require('serverless/lib/plugins/aws/provider/awsProvider')
+const ServerlessApigatewayServiceProxy = require('./../../index')
+
+chai.use(require('chai-as-promised'))
+const expect = require('chai').expect
+
+describe('#validateSnsServiceProxy()', () => {
+  let serverless
+  let serverlessApigatewayServiceProxy
+
+  beforeEach(() => {
+    serverless = new Serverless()
+    serverless.servicePath = true
+    serverless.service.service = 'apigw-service-proxy'
+    const options = {
+      stage: 'dev',
+      region: 'us-east-1'
+    }
+    serverless.setProvider('aws', new AwsProvider(serverless))
+    serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} }
+    serverlessApigatewayServiceProxy = new ServerlessApigatewayServiceProxy(serverless, options)
+  })
+
+  it('should validate the "topicName" property existence', async () => {
+    serverlessApigatewayServiceProxy.validated = {
+      events: [
+        {
+          serviceName: 'sns',
+          http: {
+            path: 'sns',
+            method: 'post'
+          }
+        }
+      ]
+    }
+
+    expect(() => serverlessApigatewayServiceProxy.validateSnsServiceProxy()).to.throw(
+      serverless.classes.Error
+    )
+  })
+
+  it('should validate the "topicName" property if it is string or AWS intrinsic function', async () => {
+    serverlessApigatewayServiceProxy.validated = {
+      events: [
+        {
+          serviceName: 'sns',
+          http: {
+            topicName: ['xx', 'yy'],
+            path: 'sns',
+            method: 'post'
+          }
+        }
+      ]
+    }
+
+    expect(() => serverlessApigatewayServiceProxy.validateSnsServiceProxy()).to.throw(
+      serverless.classes.Error
+    )
+  })
+
+  it('should validate the "topicName" property that AWS intrinsic function is correct syntax', async () => {
+    serverlessApigatewayServiceProxy.validated = {
+      events: [
+        {
+          serviceName: 'sns',
+          http: {
+            topicName: { xxx: 'SNSResourceId' },
+            path: 'sns',
+            method: 'post'
+          }
+        }
+      ]
+    }
+
+    expect(() => serverlessApigatewayServiceProxy.validateSnsServiceProxy()).to.throw(
+      serverless.classes.Error
+    )
+  })
+
+  it('should validate the "topicName" property if wrong AWS intrinsic function is specified', async () => {
+    serverlessApigatewayServiceProxy.validated = {
+      events: [
+        {
+          serviceName: 'sns',
+          http: {
+            topicName: { 'Fn::GetAtt': ['SNSResourceId', 'Arn'] },
+            path: 'sns',
+            method: 'post'
+          }
+        }
+      ]
+    }
+
+    expect(() => serverlessApigatewayServiceProxy.validateSnsServiceProxy()).to.throw(
+      serverless.classes.Error
+    )
+  })
+
+  it('should not show error if topicName is valid string', async () => {
+    serverlessApigatewayServiceProxy.validated = {
+      events: [
+        {
+          serviceName: 'sns',
+          http: {
+            topicName: 'someTopicName',
+            path: 'sns',
+            method: 'post'
+          }
+        }
+      ]
+    }
+
+    expect(() => serverlessApigatewayServiceProxy.validateSnsServiceProxy()).to.not.throw()
+  })
+
+  it('should not show error if topicName is valid intrinsic function', async () => {
+    serverlessApigatewayServiceProxy.validated = {
+      events: [
+        {
+          serviceName: 'sns',
+          http: {
+            topicName: { 'Fn::GetAtt': ['SNSResourceId', 'TopicName'] },
+            path: 'sns',
+            method: 'post'
+          }
+        }
+      ]
+    }
+
+    expect(() => serverlessApigatewayServiceProxy.validateSnsServiceProxy()).to.not.throw()
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1965,11 +1965,41 @@
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
       "dev": true
     },
+    "aws-testing-library": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/aws-testing-library/-/aws-testing-library-1.0.8.tgz",
+      "integrity": "sha512-VO48B7JcaAwW1qdrDtm8v8oAC/NyJa92yQJ6B41VWyZMs7hIz+sj3pr2QWL8CuWJTkIt6r91cA85WWo//xi3xQ==",
+      "dev": true,
+      "requires": {
+        "aws-sdk": "^2.469.0",
+        "axios": "^0.19.0",
+        "jest-diff": "^24.8.0",
+        "uuid": "^3.3.2"
+      }
+    },
     "aws4": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
+    },
+    "axios": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+          "dev": true
+        }
+      }
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -4761,6 +4791,32 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
       "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "dev": true,
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
     },
     "for-in": {
       "version": "1.0.2",
@@ -11896,6 +11952,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "uuid": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
+      "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@commitlint/cli": "^8.1.0",
     "@commitlint/config-conventional": "^8.1.0",
     "aws-sdk": "^2.496.0",
+    "aws-testing-library": "^1.0.8",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "coveralls": "^3.0.5",


### PR DESCRIPTION
Fixes #10

* This is mostly a reproduction of the process described [here](https://www.alexdebrie.com/posts/aws-api-gateway-service-proxy/#creating-the-service-proxy-integration).
* I removed some [unnecessary](https://daniel.haxx.se/blog/2015/09/11/unnecessary-use-of-curl-x/) `-X POST`  from the readme.
* Integrations tests will validate the content of the published message by attaching an SQS queue to the SNS topic (I'm using https://github.com/erezrokah/aws-testing-library, so if you don't want to introduce another dependency I can remove the content validation or implement the functionally to validate it as a part of this plugin - also I don't want to feel like I'm promoting my lib for no reason).
* Added a specific integration test to validate the custom mapping template
* Fixed some copy paste errors in `lib/package/kinesis/compileMethodsToKinesis.test.js`