### PR TITLE
Refactor: Use Fn::Sub function instead of Fn::Join

### DIFF
--- a/lib/package/kinesis/compileMethodsToKinesis.js
+++ b/lib/package/kinesis/compileMethodsToKinesis.js
@@ -54,16 +54,7 @@ module.exports = {
         'Fn::GetAtt': ['ApigatewayToKinesisRole', 'Arn']
       },
       Uri: {
-        'Fn::Join': [
-          '',
-          [
-            'arn:aws:apigateway:',
-            {
-              Ref: 'AWS::Region'
-            },
-            ':kinesis:action/PutRecord'
-          ]
-        ]
+        'Fn::Sub': 'arn:aws:apigateway:${AWS::Region}:kinesis:action/PutRecord'
       },
       PassthroughBehavior: 'NEVER',
       RequestTemplates: this.getKinesisIntegrationRequestTemplates(http)
@@ -147,27 +138,16 @@ module.exports = {
   },
 
   buildDefaultKinesisRequestTemplate(http) {
-    let streamName
-    if (typeof http.streamName == 'object') {
-      streamName = http.streamName
-    } else {
-      streamName = `"${http.streamName}"`
-    }
-
     const objectRequestParam = this.getKinesisObjectRequestParameter(http)
 
     return {
-      'Fn::Join': [
-        '',
-        [
-          '{',
-          '"StreamName": "',
-          streamName,
-          '",',
-          '"Data": "$util.base64Encode($input.body)",',
-          `"PartitionKey": "${objectRequestParam}"`,
-          '}'
-        ]
+      'Fn::Sub': [
+        '{"StreamName":"${StreamName}","Data":"${Data}","PartitionKey":"${PartitionKey}"}',
+        {
+          StreamName: http.streamName,
+          Data: '$util.base64Encode($input.body)',
+          PartitionKey: `${objectRequestParam}`
+        }
       ]
     }
   }

--- a/lib/package/kinesis/compileMethodsToKinesis.test.js
+++ b/lib/package/kinesis/compileMethodsToKinesis.test.js
@@ -70,39 +70,28 @@ describe('#compileMethodsToKinesis()', () => {
             Type: 'AWS',
             Credentials: { 'Fn::GetAtt': ['ApigatewayToKinesisRole', 'Arn'] },
             Uri: {
-              'Fn::Join': [
-                '',
-                ['arn:aws:apigateway:', { Ref: 'AWS::Region' }, ':kinesis:action/PutRecord']
-              ]
+              'Fn::Sub': 'arn:aws:apigateway:${AWS::Region}:kinesis:action/PutRecord'
             },
             PassthroughBehavior: 'NEVER',
             RequestTemplates: {
               'application/json': {
-                'Fn::Join': [
-                  '',
-                  [
-                    '{',
-                    '"StreamName": "',
-                    '"myStream"',
-                    '",',
-                    '"Data": "$util.base64Encode($input.body)",',
-                    '"PartitionKey": "$context.requestId"',
-                    '}'
-                  ]
+                'Fn::Sub': [
+                  '{"StreamName":"${StreamName}","Data":"${Data}","PartitionKey":"${PartitionKey}"}',
+                  {
+                    StreamName: 'myStream',
+                    Data: '$util.base64Encode($input.body)',
+                    PartitionKey: '$context.requestId'
+                  }
                 ]
               },
               'application/x-www-form-urlencoded': {
-                'Fn::Join': [
-                  '',
-                  [
-                    '{',
-                    '"StreamName": "',
-                    '"myStream"',
-                    '",',
-                    '"Data": "$util.base64Encode($input.body)",',
-                    '"PartitionKey": "$context.requestId"',
-                    '}'
-                  ]
+                'Fn::Sub': [
+                  '{"StreamName":"${StreamName}","Data":"${Data}","PartitionKey":"${PartitionKey}"}',
+                  {
+                    StreamName: 'myStream',
+                    Data: '$util.base64Encode($input.body)',
+                    PartitionKey: '$context.requestId'
+                  }
                 ]
               }
             },
@@ -194,39 +183,28 @@ describe('#compileMethodsToKinesis()', () => {
             Type: 'AWS',
             Credentials: { 'Fn::GetAtt': ['ApigatewayToKinesisRole', 'Arn'] },
             Uri: {
-              'Fn::Join': [
-                '',
-                ['arn:aws:apigateway:', { Ref: 'AWS::Region' }, ':kinesis:action/PutRecord']
-              ]
+              'Fn::Sub': 'arn:aws:apigateway:${AWS::Region}:kinesis:action/PutRecord'
             },
             PassthroughBehavior: 'NEVER',
             RequestTemplates: {
               'application/json': {
-                'Fn::Join': [
-                  '',
-                  [
-                    '{',
-                    '"StreamName": "',
-                    '"myStream"',
-                    '",',
-                    '"Data": "$util.base64Encode($input.body)",',
-                    '"PartitionKey": "$context.requestId"',
-                    '}'
-                  ]
+                'Fn::Sub': [
+                  '{"StreamName":"${StreamName}","Data":"${Data}","PartitionKey":"${PartitionKey}"}',
+                  {
+                    StreamName: 'myStream',
+                    Data: '$util.base64Encode($input.body)',
+                    PartitionKey: '$context.requestId'
+                  }
                 ]
               },
               'application/x-www-form-urlencoded': {
-                'Fn::Join': [
-                  '',
-                  [
-                    '{',
-                    '"StreamName": "',
-                    '"myStream"',
-                    '",',
-                    '"Data": "$util.base64Encode($input.body)",',
-                    '"PartitionKey": "$context.requestId"',
-                    '}'
-                  ]
+                'Fn::Sub': [
+                  '{"StreamName":"${StreamName}","Data":"${Data}","PartitionKey":"${PartitionKey}"}',
+                  {
+                    StreamName: 'myStream',
+                    Data: '$util.base64Encode($input.body)',
+                    PartitionKey: '$context.requestId'
+                  }
                 ]
               }
             },
@@ -276,6 +254,7 @@ describe('#compileMethodsToKinesis()', () => {
   it('should return the default template for application/json when one is not given', async () => {
     const httpWithoutRequestTemplate = {
       path: 'foo/bar1',
+      streamName: 'myStream',
       method: 'post',
       request: {
         template: {
@@ -292,18 +271,14 @@ describe('#compileMethodsToKinesis()', () => {
     )
 
     expect(
-      resource.Properties.Integration.RequestTemplates['application/json']['Fn::Join']
+      resource.Properties.Integration.RequestTemplates['application/json']['Fn::Sub']
     ).to.be.deep.equal([
-      '',
-      [
-        '{',
-        '"StreamName": "',
-        '"undefined"',
-        '",',
-        '"Data": "$util.base64Encode($input.body)",',
-        '"PartitionKey": "$context.requestId"',
-        '}'
-      ]
+      '{"StreamName":"${StreamName}","Data":"${Data}","PartitionKey":"${PartitionKey}"}',
+      {
+        StreamName: 'myStream',
+        Data: '$util.base64Encode($input.body)',
+        PartitionKey: '$context.requestId'
+      }
     ])
   })
 
@@ -325,18 +300,14 @@ describe('#compileMethodsToKinesis()', () => {
     )
 
     expect(
-      resource.Properties.Integration.RequestTemplates['application/json']['Fn::Join']
+      resource.Properties.Integration.RequestTemplates['application/json']['Fn::Sub']
     ).to.be.deep.equal([
-      '',
-      [
-        '{',
-        '"StreamName": "',
-        '"testStream"',
-        '",',
-        '"Data": "$util.base64Encode($input.body)",',
-        '"PartitionKey": "$input.params().path.key1"',
-        '}'
-      ]
+      '{"StreamName":"${StreamName}","Data":"${Data}","PartitionKey":"${PartitionKey}"}',
+      {
+        StreamName: 'testStream',
+        Data: '$util.base64Encode($input.body)',
+        PartitionKey: '$input.params().path.key1'
+      }
     ])
   })
 
@@ -358,18 +329,14 @@ describe('#compileMethodsToKinesis()', () => {
     )
 
     expect(
-      resource.Properties.Integration.RequestTemplates['application/json']['Fn::Join']
+      resource.Properties.Integration.RequestTemplates['application/json']['Fn::Sub']
     ).to.be.deep.equal([
-      '',
-      [
-        '{',
-        '"StreamName": "',
-        '"testStream"',
-        '",',
-        '"Data": "$util.base64Encode($input.body)",',
-        '"PartitionKey": "$util.parseJson($input.body).data.messageId"',
-        '}'
-      ]
+      '{"StreamName":"${StreamName}","Data":"${Data}","PartitionKey":"${PartitionKey}"}',
+      {
+        StreamName: 'testStream',
+        Data: '$util.base64Encode($input.body)',
+        PartitionKey: '$util.parseJson($input.body).data.messageId'
+      }
     ])
   })
 
@@ -391,18 +358,14 @@ describe('#compileMethodsToKinesis()', () => {
     )
 
     expect(
-      resource.Properties.Integration.RequestTemplates['application/json']['Fn::Join']
+      resource.Properties.Integration.RequestTemplates['application/json']['Fn::Sub']
     ).to.be.deep.equal([
-      '',
-      [
-        '{',
-        '"StreamName": "',
-        '"testStream"',
-        '",',
-        '"Data": "$util.base64Encode($input.body)",',
-        '"PartitionKey": "$input.params().querystring.key"',
-        '}'
-      ]
+      '{"StreamName":"${StreamName}","Data":"${Data}","PartitionKey":"${PartitionKey}"}',
+      {
+        StreamName: 'testStream',
+        Data: '$util.base64Encode($input.body)',
+        PartitionKey: '$input.params().querystring.key'
+      }
     ])
   })
 
@@ -421,18 +384,14 @@ describe('#compileMethodsToKinesis()', () => {
     )
 
     expect(
-      resource.Properties.Integration.RequestTemplates['application/json']['Fn::Join']
+      resource.Properties.Integration.RequestTemplates['application/json']['Fn::Sub']
     ).to.be.deep.equal([
-      '',
-      [
-        '{',
-        '"StreamName": "',
-        '"testStream"',
-        '",',
-        '"Data": "$util.base64Encode($input.body)",',
-        '"PartitionKey": "$context.requestId"',
-        '}'
-      ]
+      '{"StreamName":"${StreamName}","Data":"${Data}","PartitionKey":"${PartitionKey}"}',
+      {
+        StreamName: 'testStream',
+        Data: '$util.base64Encode($input.body)',
+        PartitionKey: '$context.requestId'
+      }
     ])
   })
 
@@ -452,18 +411,14 @@ describe('#compileMethodsToKinesis()', () => {
     )
 
     expect(
-      resource.Properties.Integration.RequestTemplates['application/json']['Fn::Join']
+      resource.Properties.Integration.RequestTemplates['application/json']['Fn::Sub']
     ).to.be.deep.equal([
-      '',
-      [
-        '{',
-        '"StreamName": "',
-        '"testStream"',
-        '",',
-        '"Data": "$util.base64Encode($input.body)",',
-        '"PartitionKey": "mykey"',
-        '}'
-      ]
+      '{"StreamName":"${StreamName}","Data":"${Data}","PartitionKey":"${PartitionKey}"}',
+      {
+        StreamName: 'testStream',
+        Data: '$util.base64Encode($input.body)',
+        PartitionKey: 'mykey'
+      }
     ])
   })
 
@@ -490,6 +445,7 @@ describe('#compileMethodsToKinesis()', () => {
 
   it('should return the default for application/x-www-form-urlencoded when one is not given', async () => {
     const httpWithoutRequestTemplate = {
+      streamName: 'myStream',
       path: 'foo/bar1',
       method: 'post',
       request: {
@@ -506,19 +462,15 @@ describe('#compileMethodsToKinesis()', () => {
     )
     expect(
       resource.Properties.Integration.RequestTemplates['application/x-www-form-urlencoded'][
-        'Fn::Join'
+        'Fn::Sub'
       ]
     ).to.be.deep.equal([
-      '',
-      [
-        '{',
-        '"StreamName": "',
-        '"undefined"',
-        '",',
-        '"Data": "$util.base64Encode($input.body)",',
-        '"PartitionKey": "$context.requestId"',
-        '}'
-      ]
+      '{"StreamName":"${StreamName}","Data":"${Data}","PartitionKey":"${PartitionKey}"}',
+      {
+        StreamName: 'myStream',
+        Data: '$util.base64Encode($input.body)',
+        PartitionKey: '$context.requestId'
+      }
     ])
   })
 
@@ -615,39 +567,28 @@ describe('#compileMethodsToKinesis()', () => {
             Type: 'AWS',
             Credentials: { 'Fn::GetAtt': ['ApigatewayToKinesisRole', 'Arn'] },
             Uri: {
-              'Fn::Join': [
-                '',
-                ['arn:aws:apigateway:', { Ref: 'AWS::Region' }, ':kinesis:action/PutRecord']
-              ]
+              'Fn::Sub': 'arn:aws:apigateway:${AWS::Region}:kinesis:action/PutRecord'
             },
             PassthroughBehavior: 'NEVER',
             RequestTemplates: {
               'application/json': {
-                'Fn::Join': [
-                  '',
-                  [
-                    '{',
-                    '"StreamName": "',
-                    '"myStream"',
-                    '",',
-                    '"Data": "$util.base64Encode($input.body)",',
-                    '"PartitionKey": "$context.requestId"',
-                    '}'
-                  ]
+                'Fn::Sub': [
+                  '{"StreamName":"${StreamName}","Data":"${Data}","PartitionKey":"${PartitionKey}"}',
+                  {
+                    StreamName: 'myStream',
+                    Data: '$util.base64Encode($input.body)',
+                    PartitionKey: '$context.requestId'
+                  }
                 ]
               },
               'application/x-www-form-urlencoded': {
-                'Fn::Join': [
-                  '',
-                  [
-                    '{',
-                    '"StreamName": "',
-                    '"myStream"',
-                    '",',
-                    '"Data": "$util.base64Encode($input.body)",',
-                    '"PartitionKey": "$context.requestId"',
-                    '}'
-                  ]
+                'Fn::Sub': [
+                  '{"StreamName":"${StreamName}","Data":"${Data}","PartitionKey":"${PartitionKey}"}',
+                  {
+                    StreamName: 'myStream',
+                    Data: '$util.base64Encode($input.body)',
+                    PartitionKey: '$context.requestId'
+                  }
                 ]
               }
             },
@@ -726,39 +667,28 @@ describe('#compileMethodsToKinesis()', () => {
             Type: 'AWS',
             Credentials: { 'Fn::GetAtt': ['ApigatewayToKinesisRole', 'Arn'] },
             Uri: {
-              'Fn::Join': [
-                '',
-                ['arn:aws:apigateway:', { Ref: 'AWS::Region' }, ':kinesis:action/PutRecord']
-              ]
+              'Fn::Sub': 'arn:aws:apigateway:${AWS::Region}:kinesis:action/PutRecord'
             },
             PassthroughBehavior: 'NEVER',
             RequestTemplates: {
               'application/json': {
-                'Fn::Join': [
-                  '',
-                  [
-                    '{',
-                    '"StreamName": "',
-                    '"myStream"',
-                    '",',
-                    '"Data": "$util.base64Encode($input.body)",',
-                    '"PartitionKey": "$context.requestId"',
-                    '}'
-                  ]
+                'Fn::Sub': [
+                  '{"StreamName":"${StreamName}","Data":"${Data}","PartitionKey":"${PartitionKey}"}',
+                  {
+                    StreamName: 'myStream',
+                    Data: '$util.base64Encode($input.body)',
+                    PartitionKey: '$context.requestId'
+                  }
                 ]
               },
               'application/x-www-form-urlencoded': {
-                'Fn::Join': [
-                  '',
-                  [
-                    '{',
-                    '"StreamName": "',
-                    '"myStream"',
-                    '",',
-                    '"Data": "$util.base64Encode($input.body)",',
-                    '"PartitionKey": "$context.requestId"',
-                    '}'
-                  ]
+                'Fn::Sub': [
+                  '{"StreamName":"${StreamName}","Data":"${Data}","PartitionKey":"${PartitionKey}"}',
+                  {
+                    StreamName: 'myStream',
+                    Data: '$util.base64Encode($input.body)',
+                    PartitionKey: '$context.requestId'
+                  }
                 ]
               }
             },

--- a/lib/package/sqs/compileMethodsToSqs.js
+++ b/lib/package/sqs/compileMethodsToSqs.js
@@ -47,10 +47,6 @@ module.exports = {
   },
 
   getSqsMethodIntegration(http) {
-    let queueName = http.queueName
-    if (typeof http.queueName == 'string') {
-      queueName = `"${queueName}"`
-    }
     const integration = {
       IntegrationHttpMethod: 'POST',
       Type: 'AWS',
@@ -58,20 +54,9 @@ module.exports = {
         'Fn::GetAtt': ['ApigatewayToSqsRole', 'Arn']
       },
       Uri: {
-        'Fn::Join': [
-          '',
-          [
-            'arn:aws:apigateway:',
-            {
-              Ref: 'AWS::Region'
-            },
-            ':sqs:path//',
-            {
-              Ref: 'AWS::AccountId'
-            },
-            '/',
-            queueName
-          ]
+        'Fn::Sub': [
+          'arn:aws:apigateway:${AWS::Region}:sqs:path//${AWS::AccountId}/${queueName}',
+          { queueName: http.queueName }
         ]
       },
       RequestParameters: _.merge(

--- a/lib/package/sqs/compileMethodsToSqs.test.js
+++ b/lib/package/sqs/compileMethodsToSqs.test.js
@@ -67,16 +67,11 @@ describe('#compileMethodsToSqs()', () => {
             Type: 'AWS',
             Credentials: { 'Fn::GetAtt': ['ApigatewayToSqsRole', 'Arn'] },
             Uri: {
-              'Fn::Join': [
-                '',
-                [
-                  'arn:aws:apigateway:',
-                  { Ref: 'AWS::Region' },
-                  ':sqs:path//',
-                  { Ref: 'AWS::AccountId' },
-                  '/',
-                  '"myQueue"'
-                ]
+              'Fn::Sub': [
+                'arn:aws:apigateway:${AWS::Region}:sqs:path//${AWS::AccountId}/${queueName}',
+                {
+                  queueName: 'myQueue'
+                }
               ]
             },
             RequestParameters: {
@@ -171,16 +166,11 @@ describe('#compileMethodsToSqs()', () => {
             Type: 'AWS',
             Credentials: { 'Fn::GetAtt': ['ApigatewayToSqsRole', 'Arn'] },
             Uri: {
-              'Fn::Join': [
-                '',
-                [
-                  'arn:aws:apigateway:',
-                  { Ref: 'AWS::Region' },
-                  ':sqs:path//',
-                  { Ref: 'AWS::AccountId' },
-                  '/',
-                  '"myQueue"'
-                ]
+              'Fn::Sub': [
+                'arn:aws:apigateway:${AWS::Region}:sqs:path//${AWS::AccountId}/${queueName}',
+                {
+                  queueName: 'myQueue'
+                }
               ]
             },
             RequestParameters: {
@@ -274,16 +264,11 @@ describe('#compileMethodsToSqs()', () => {
             Type: 'AWS',
             Credentials: { 'Fn::GetAtt': ['ApigatewayToSqsRole', 'Arn'] },
             Uri: {
-              'Fn::Join': [
-                '',
-                [
-                  'arn:aws:apigateway:',
-                  { Ref: 'AWS::Region' },
-                  ':sqs:path//',
-                  { Ref: 'AWS::AccountId' },
-                  '/',
-                  '"myQueue"'
-                ]
+              'Fn::Sub': [
+                'arn:aws:apigateway:${AWS::Region}:sqs:path//${AWS::AccountId}/${queueName}',
+                {
+                  queueName: 'myQueue'
+                }
               ]
             },
             RequestParameters: {
@@ -365,16 +350,11 @@ describe('#compileMethodsToSqs()', () => {
             Type: 'AWS',
             Credentials: { 'Fn::GetAtt': ['ApigatewayToSqsRole', 'Arn'] },
             Uri: {
-              'Fn::Join': [
-                '',
-                [
-                  'arn:aws:apigateway:',
-                  { Ref: 'AWS::Region' },
-                  ':sqs:path//',
-                  { Ref: 'AWS::AccountId' },
-                  '/',
-                  '"myQueue"'
-                ]
+              'Fn::Sub': [
+                'arn:aws:apigateway:${AWS::Region}:sqs:path//${AWS::AccountId}/${queueName}',
+                {
+                  queueName: 'myQueue'
+                }
               ]
             },
             RequestParameters: {
@@ -456,16 +436,11 @@ describe('#compileMethodsToSqs()', () => {
             Type: 'AWS',
             Credentials: { 'Fn::GetAtt': ['ApigatewayToSqsRole', 'Arn'] },
             Uri: {
-              'Fn::Join': [
-                '',
-                [
-                  'arn:aws:apigateway:',
-                  { Ref: 'AWS::Region' },
-                  ':sqs:path//',
-                  { Ref: 'AWS::AccountId' },
-                  '/',
-                  '"myQueue"'
-                ]
+              'Fn::Sub': [
+                'arn:aws:apigateway:${AWS::Region}:sqs:path//${AWS::AccountId}/${queueName}',
+                {
+                  queueName: 'myQueue'
+                }
               ]
             },
             RequestParameters: {


### PR DESCRIPTION
All `Fn::Join` intrinsic functions was replaced with `Fn::Sub` in this plugin.