### PR TITLE
feat: add timestamp s3 key option

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,16 @@ custom:
           queryStringParam: key # use query string param
         cors: true
 
+    - s3:
+        path: /s3
+        method: post
+        action: PutObject
+        bucket:
+          Ref: S3Bucket
+        key:
+          timestamp: foo # use timestamp & prefix (YYYY/MM/DD/HH/foo-YYYY-DD-MM-HH-mm-ss-ms)
+        cors: true
+
 resources:
   Resources:
     S3Bucket:

--- a/lib/package/s3/compileMethodsToS3.js
+++ b/lib/package/s3/compileMethodsToS3.js
@@ -82,6 +82,25 @@ module.exports = {
       return `method.request.querystring.${http.key.queryStringParam}`
     }
 
+    if (http.key.timestamp) {
+      function zeroPad(n) {
+        return ('0' + n).slice(-2)
+      }
+      const now = new Date()
+      const timestamp = now
+        .toISOString()
+        .replace(/Z/, '')
+        .replace(/(T|:|-|\.)/g, '-')
+      const key = [
+        now.getFullYear(),
+        zeroPad(now.getMonth() + 1),
+        zeroPad(now.getDate()),
+        zeroPad(now.getHours()),
+        `${http.key.timestamp}-${timestamp}`
+      ].join('/')
+      return `'${key}'`
+    }
+
     return `'${http.key}'`
   },
 


### PR DESCRIPTION
In the scenario that I am using S3 integration I have no control over the way the API GW endpoint is called: it is not possible to provide a querystring or path parameter to vary the S3 key name.

The alternative could be to simply overwrite the same static key repeatedly but this is undesirable.

The proposed changes allow the current time, with prefix, to be used as the key name. 

NOTE: I wasn't able to add tests... I am not sure of the correct way to mock the current time. I experimented with using `new DateTime` within the test but this was flaky/failing.

Happy to receive feedback :-D