### PR TITLE
Feat: add serverless offline support - WIP DO NOT MERGE

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26,6 +26,8 @@ const compileMethodsToSns = require('./package/sns/compileMethodsToSns')
 const compileIamRoleToSns = require('./package/sns/compileIamRoleToSns')
 const compileSnsServiceProxy = require('./package/sns/compileSnsServiceProxy')
 
+const _ = require('lodash')
+
 class ServerlessApigatewayServiceProxy {
   constructor(serverless, options) {
     this.serverless = serverless
@@ -60,28 +62,16 @@ class ServerlessApigatewayServiceProxy {
     )
 
     this.hooks = {
+      'before:offline:start:init': async () => {
+        this.serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} }
+        await this.compileProxies()
+        _.merge(
+          this.serverless.service.resources,
+          this.serverless.service.provider.compiledCloudFormationTemplate
+        )
+      },
       'package:compileEvents': async () => {
-        if (this.getAllServiceProxies().length > 0) {
-          this.validated = await this.validateServiceProxies()
-
-          await this.compileRestApi()
-          await this.compileResources()
-          await this.compileCors()
-
-          //Kinesis proxy
-          await this.compileKinesisServiceProxy()
-
-          // SQS getProxy
-          await this.compileSqsServiceProxy()
-
-          // S3 getProxy
-          await this.compileS3ServiceProxy()
-
-          // SNS getProxy
-          await this.compileSnsServiceProxy()
-
-          await this.mergeDeployment()
-        }
+        await this.compileProxies()
       },
       'after:deploy:deploy': async () => {
         if (this.getAllServiceProxies().length > 0) {
@@ -89,6 +79,30 @@ class ServerlessApigatewayServiceProxy {
           await this.display()
         }
       }
+    }
+  }
+
+  async compileProxies() {
+    if (this.getAllServiceProxies().length > 0) {
+      this.validated = await this.validateServiceProxies()
+
+      await this.compileRestApi()
+      await this.compileResources()
+      await this.compileCors()
+
+      //Kinesis proxy
+      await this.compileKinesisServiceProxy()
+
+      // SQS getProxy
+      await this.compileSqsServiceProxy()
+
+      // S3 getProxy
+      await this.compileS3ServiceProxy()
+
+      // SNS getProxy
+      await this.compileSnsServiceProxy()
+
+      await this.mergeDeployment()
     }
   }
 

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -39,8 +39,12 @@ describe('#index()', () => {
       expect(serverlessApigatewayServiceProxy.options).to.be.empty
     })
 
-    it('should have hooks', () => {
-      expect(serverlessApigatewayServiceProxy.hooks).to.be.not.empty
+    it('should register hooks', () => {
+      expect(serverlessApigatewayServiceProxy.hooks).to.have.keys(
+        'before:offline:start:init',
+        'package:compileEvents',
+        'after:deploy:deploy'
+      )
     })
 
     it('should set the provider variable to an instance of AwsProvider', () => {
@@ -246,6 +250,32 @@ describe('#index()', () => {
 
       serverlessApigatewayServiceProxy.getStackInfo.restore()
       serverlessApigatewayServiceProxy.display.restore()
+    })
+
+    it('should compile proxies and assign to service resources on before:offline:start:init', async () => {
+      serverlessApigatewayServiceProxy.serverless.service.custom = {
+        apiGatewayServiceProxies: [
+          {
+            kinesis: {
+              path: '/kinesis',
+              method: 'post',
+              streamName: 'streamName'
+            }
+          }
+        ]
+      }
+
+      await expect(
+        serverlessApigatewayServiceProxy.hooks['before:offline:start:init']()
+      ).to.be.fulfilled.then(() => {
+        expect(
+          serverlessApigatewayServiceProxy.serverless.service.resources.Resources
+        ).to.have.any.keys(
+          'ApiGatewayMethodKinesisPost',
+          'ApiGatewayResourceKinesis',
+          'ApigatewayToKinesisRole'
+        )
+      })
     })
   })
 


### PR DESCRIPTION
Initial support for #39 

Additional support is required from the serverless offline plugin.

Currently the serverless offline plugin only supports [`HTTP_PROXY`](https://github.com/dherault/serverless-offline#http-proxy) by adding the following configuration:

```
custom:
  serverless-offline:
    resourceRoutes: true
```
Relevant code is here https://github.com/dherault/serverless-offline/blob/8e62f767dd95d027378ee04c6cb98676726fa5f9/src/api-gateway/parseResources.js#L167

In any case I think it will only be relevant for S3 and DynamoDB
