### PR TITLE
feat: support customizing method request parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ custom:
         requestParameters:
           # if requestParameters has a 'integration.request.path.object' property you should remove the key setting
           'integration.request.path.object': 'context.requestId'
-          "integration.request.header.cache-control": "'public, max-age=31536000, immutable'"
+          'integration.request.header.cache-control': "'public, max-age=31536000, immutable'"
 ```
 
 ### SNS
@@ -352,6 +352,34 @@ resources:
       # Custom Role definition
       Type: 'AWS::IAM::Role'
 ```
+
+### Customizing API Gateway parameters
+
+The plugin allows one to specify which [parameters the API Gateway method accepts](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-method.html#cfn-apigateway-method-requestparameters).
+
+A common use case is to pass custom data to the integration request:
+
+```yaml
+custom:
+  apiGatewayServiceProxies:
+    - sqs:
+        path: /sqs
+        method: post
+        queueName: { 'Fn::GetAtt': ['SqsQueue', 'QueueName'] }
+        cors: true
+        acceptParameters:
+          'method.request.header.Custom-Header': true
+        requestParameters:
+          'integration.request.querystring.MessageAttribute.1.Name': "'custom-Header'"
+          'integration.request.querystring.MessageAttribute.1.Value.StringValue': 'method.request.header.Custom-Header'
+          'integration.request.querystring.MessageAttribute.1.Value.DataType': "'String'"
+resources:
+  Resources:
+    SqsQueue:
+      Type: 'AWS::SQS::Queue'
+```
+
+Any published SQS message will have the `Custom-Header` value added as a message attribute.
 
 ### Customizing request body mapping templates
 

--- a/__tests__/integration/common/accept-parameters/service/serverless.yml
+++ b/__tests__/integration/common/accept-parameters/service/serverless.yml
@@ -1,0 +1,32 @@
+service: accept-parameters-proxy
+
+provider:
+  name: aws
+  runtime: nodejs10.x
+
+plugins:
+  localPath: './../../../../../../'
+  modules:
+    - serverless-apigateway-service-proxy
+
+custom:
+  apiGatewayServiceProxies:
+    - sqs:
+        path: /sqs
+        method: post
+        queueName: { 'Fn::GetAtt': ['SqsQueue', 'QueueName'] }
+        cors: true
+        acceptParameters:
+          'method.request.header.Custom-Header': true
+        requestParameters:
+          'integration.request.querystring.MessageAttribute.1.Name': "'custom-Header'"
+          'integration.request.querystring.MessageAttribute.1.Value.StringValue': 'method.request.header.Custom-Header'
+          'integration.request.querystring.MessageAttribute.1.Value.DataType': "'String'"
+
+resources:
+  Resources:
+    SqsQueue:
+      Type: 'AWS::SQS::Queue'
+  Outputs:
+    SqsQueueUrl:
+      Value: { Ref: SqsQueue }

--- a/__tests__/integration/common/accept-parameters/tests.js
+++ b/__tests__/integration/common/accept-parameters/tests.js
@@ -1,0 +1,68 @@
+'use strict'
+const AWS = require('aws-sdk')
+const expect = require('chai').expect
+
+const fetch = require('node-fetch')
+const { deployWithRandomStage, removeService } = require('../../../utils')
+
+describe('Single SQS Proxy Integration Test', () => {
+  let endpoint
+  let region
+  let stage
+  let queueUrl
+  const config = '__tests__/integration/common/accept-parameters/service/serverless.yml'
+
+  beforeAll(async () => {
+    const result = await deployWithRandomStage(config)
+
+    region = result.region
+    stage = result.stage
+    endpoint = result.endpoint
+    queueUrl = result.outputs.SqsQueueUrl
+  })
+
+  afterAll(() => {
+    removeService(stage, config)
+  })
+
+  it('should pass custom header to sqs message attribute', async () => {
+    const testEndpoint = `${endpoint}/sqs`
+
+    const body = JSON.stringify({ message: 'test accept parameters' })
+    const response = await fetch(testEndpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Custom-Header': 'custom header value' },
+      body
+    })
+
+    expect(response.headers.get('access-control-allow-origin')).to.deep.equal('*')
+    expect(response.status).to.be.equal(200)
+
+    const json = await response.json()
+
+    expect(json.SendMessageResponse.SendMessageResult).to.have.own.property(
+      'MD5OfMessageAttributes'
+    )
+    expect(json.SendMessageResponse.SendMessageResult).to.have.own.property('MD5OfMessageBody')
+    expect(json.SendMessageResponse.SendMessageResult).to.have.own.property('MessageId')
+    expect(json.SendMessageResponse.SendMessageResult).to.have.own.property('SequenceNumber')
+    expect(json.SendMessageResponse.ResponseMetadata).to.have.own.property('RequestId')
+
+    const sqs = new AWS.SQS({ region })
+    const { Messages = [] } = await sqs
+      .receiveMessage({ QueueUrl: queueUrl, WaitTimeSeconds: 20, MessageAttributeNames: ['.*'] })
+      .promise()
+
+    expect(Messages).to.have.length(1)
+    expect(Messages[0].Body).to.deep.equal(body)
+
+    expect(Messages[0].MessageAttributes).to.deep.equal({
+      'custom-Header': {
+        StringValue: 'custom header value',
+        StringListValues: [],
+        BinaryListValues: [],
+        DataType: 'String'
+      }
+    })
+  })
+})

--- a/lib/apiGateway/schema.js
+++ b/lib/apiGateway/schema.js
@@ -89,6 +89,8 @@ const stringOrGetAtt = (propertyName, attributeName) => {
 
 const roleArn = stringOrGetAtt('roleArn', 'Arn')
 
+const acceptParameters = Joi.object().pattern(Joi.string(), Joi.boolean().required())
+
 const proxy = Joi.object({
   path,
   method,
@@ -96,7 +98,8 @@ const proxy = Joi.object({
   authorizationType,
   authorizerId,
   authorizationScopes,
-  roleArn
+  roleArn,
+  acceptParameters
 })
   .oxor('authorizerId', 'authorizationScopes') // can have one of them, but not required
   .error(

--- a/lib/apiGateway/validate.test.js
+++ b/lib/apiGateway/validate.test.js
@@ -673,6 +673,49 @@ describe('#validateServiceProxies()', () => {
       expect(() => serverlessApigatewayServiceProxy.validateServiceProxies()).to.not.throw()
     })
 
+    it('should throw if "acceptParameters" is not a string to boolean mapping', () => {
+      serverlessApigatewayServiceProxy.serverless.service.custom = {
+        apiGatewayServiceProxies: [
+          {
+            kinesis: {
+              path: '/kinesis',
+              streamName: 'streamName',
+              method: 'post',
+              acceptParameters: {
+                'method.request.header.customHeader1': 'this is not a boolean',
+                'method.request.header.customHeader2': 1000
+              }
+            }
+          }
+        ]
+      }
+
+      expect(() => serverlessApigatewayServiceProxy.validateServiceProxies()).to.throw(
+        serverless.classes.Error,
+        'child "kinesis" fails because [child "acceptParameters" fails because [child "method.request.header.customHeader1" fails because ["method.request.header.customHeader1" must be a boolean]]'
+      )
+    })
+
+    it('should not throw if "acceptParameters" is a string to boolean mapping', () => {
+      serverlessApigatewayServiceProxy.serverless.service.custom = {
+        apiGatewayServiceProxies: [
+          {
+            kinesis: {
+              path: '/kinesis',
+              streamName: 'streamName',
+              method: 'post',
+              acceptParameters: {
+                'method.request.header.customHeader1': true,
+                'method.request.header.customHeader2': false
+              }
+            }
+          }
+        ]
+      }
+
+      expect(() => serverlessApigatewayServiceProxy.validateServiceProxies()).to.not.throw()
+    })
+
     const proxiesToTest = [
       { proxy: 'kinesis', props: { streamName: 'streamName' } },
       { proxy: 'sns', props: { topicName: 'topicName' } }

--- a/lib/package/kinesis/compileMethodsToKinesis.js
+++ b/lib/package/kinesis/compileMethodsToKinesis.js
@@ -13,7 +13,7 @@ module.exports = {
           Type: 'AWS::ApiGateway::Method',
           Properties: {
             HttpMethod: event.http.method.toUpperCase(),
-            RequestParameters: {},
+            RequestParameters: event.http.acceptParameters || {},
             AuthorizationType: event.http.auth.authorizationType,
             AuthorizationScopes: event.http.auth.authorizationScopes,
             AuthorizerId: event.http.auth.authorizerId,

--- a/lib/package/kinesis/compileMethodsToKinesis.test.js
+++ b/lib/package/kinesis/compileMethodsToKinesis.test.js
@@ -734,4 +734,37 @@ describe('#compileMethodsToKinesis()', () => {
     const resource = serverlessApigatewayServiceProxy.getKinesisMethodIntegration(http)
     expect(resource.Properties.Integration.Credentials).to.be.equal('roleArn')
   })
+
+  it('should set RequestParameters to acceptParameters when configured', () => {
+    serverlessApigatewayServiceProxy.validated = {
+      events: [
+        {
+          serviceName: 'kinesis',
+          http: {
+            streamName: 'myStream',
+            path: 'kinesis',
+            method: 'post',
+            auth: {
+              authorizationType: 'NONE'
+            },
+            acceptParameters: { 'method.request.header.Custom-Header': true }
+          }
+        }
+      ]
+    }
+    serverlessApigatewayServiceProxy.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi'
+    serverlessApigatewayServiceProxy.apiGatewayResources = {
+      kinesis: {
+        name: 'kinesis',
+        resourceLogicalId: 'ApiGatewayResourceKinesis'
+      }
+    }
+
+    serverlessApigatewayServiceProxy.compileMethodsToKinesis()
+
+    expect(
+      serverless.service.provider.compiledCloudFormationTemplate.Resources
+        .ApiGatewayMethodkinesisPost.Properties.RequestParameters
+    ).to.be.deep.equal({ 'method.request.header.Custom-Header': true })
+  })
 })

--- a/lib/package/s3/compileMethodsToS3.js
+++ b/lib/package/s3/compileMethodsToS3.js
@@ -13,7 +13,7 @@ module.exports = {
           Type: 'AWS::ApiGateway::Method',
           Properties: {
             HttpMethod: event.http.method.toUpperCase(),
-            RequestParameters: {},
+            RequestParameters: event.http.acceptParameters || {},
             AuthorizationType: event.http.auth.authorizationType,
             AuthorizationScopes: event.http.auth.authorizationScopes,
             AuthorizerId: event.http.auth.authorizerId,

--- a/lib/package/s3/compileMethodsToS3.test.js
+++ b/lib/package/s3/compileMethodsToS3.test.js
@@ -639,4 +639,46 @@ describe('#compileMethodsToS3()', () => {
     const resource = serverlessApigatewayServiceProxy.getS3MethodIntegration(http)
     expect(resource.Properties.Integration.Credentials).to.be.equal('roleArn')
   })
+
+  it('should set RequestParameters to acceptParameters when configured', () => {
+    serverlessApigatewayServiceProxy.validated = {
+      events: [
+        {
+          serviceName: 's3',
+          http: {
+            path: 's3',
+            method: 'post',
+            bucket: {
+              Ref: 'MyBucket'
+            },
+            action: 'PutObject',
+            key: {
+              pathParam: 'key'
+            },
+            cors: true,
+            auth: { authorizationType: 'NONE' },
+            acceptParameters: { 'method.request.header.Custom-Header': false }
+          }
+        }
+      ]
+    }
+    serverlessApigatewayServiceProxy.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi'
+    serverlessApigatewayServiceProxy.apiGatewayResources = {
+      s3: {
+        name: 's3',
+        resourceLogicalId: 'ApiGatewayResourceS3'
+      }
+    }
+
+    serverlessApigatewayServiceProxy.compileMethodsToS3()
+
+    expect(
+      serverless.service.provider.compiledCloudFormationTemplate.Resources.ApiGatewayMethods3Post
+        .Properties.RequestParameters
+    ).to.be.deep.equal({
+      'method.request.header.Custom-Header': false,
+      'method.request.header.Content-Type': true,
+      'method.request.path.key': true
+    })
+  })
 })

--- a/lib/package/sns/compileMethodsToSns.js
+++ b/lib/package/sns/compileMethodsToSns.js
@@ -13,7 +13,7 @@ module.exports = {
           Type: 'AWS::ApiGateway::Method',
           Properties: {
             HttpMethod: event.http.method.toUpperCase(),
-            RequestParameters: {},
+            RequestParameters: event.http.acceptParameters || {},
             AuthorizationType: event.http.auth.authorizationType,
             AuthorizationScopes: event.http.auth.authorizationScopes,
             AuthorizerId: event.http.auth.authorizerId,

--- a/lib/package/sns/compileMethodsToSns.test.js
+++ b/lib/package/sns/compileMethodsToSns.test.js
@@ -657,4 +657,37 @@ describe('#compileMethodsToSns()', () => {
     const resource = serverlessApigatewayServiceProxy.getSnsMethodIntegration(http)
     expect(resource.Properties.Integration.Credentials).to.be.equal('roleArn')
   })
+
+  it('should set RequestParameters to acceptParameters when configured', () => {
+    serverlessApigatewayServiceProxy.validated = {
+      events: [
+        {
+          serviceName: 'sns',
+          http: {
+            topicName: 'myTopic',
+            path: 'sns',
+            method: 'post',
+            auth: {
+              authorizationType: 'NONE'
+            },
+            acceptParameters: { 'method.request.header.Custom-Header': true }
+          }
+        }
+      ]
+    }
+    serverlessApigatewayServiceProxy.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi'
+    serverlessApigatewayServiceProxy.apiGatewayResources = {
+      sns: {
+        name: 'Sns',
+        resourceLogicalId: 'ApiGatewayResourceSns'
+      }
+    }
+
+    serverlessApigatewayServiceProxy.compileMethodsToSns()
+
+    expect(
+      serverless.service.provider.compiledCloudFormationTemplate.Resources.ApiGatewayMethodSnsPost
+        .Properties.RequestParameters
+    ).to.be.deep.equal({ 'method.request.header.Custom-Header': true })
+  })
 })

--- a/lib/package/sqs/compileMethodsToSqs.js
+++ b/lib/package/sqs/compileMethodsToSqs.js
@@ -13,7 +13,7 @@ module.exports = {
           Type: 'AWS::ApiGateway::Method',
           Properties: {
             HttpMethod: event.http.method.toUpperCase(),
-            RequestParameters: {},
+            RequestParameters: event.http.acceptParameters || {},
             AuthorizationScopes: event.http.auth.authorizationScopes,
             AuthorizationType: event.http.auth.authorizationType,
             AuthorizerId: event.http.auth.authorizerId,

--- a/lib/package/sqs/compileMethodsToSqs.test.js
+++ b/lib/package/sqs/compileMethodsToSqs.test.js
@@ -524,4 +524,37 @@ describe('#compileMethodsToSqs()', () => {
     const resource = serverlessApigatewayServiceProxy.getSqsMethodIntegration(http)
     expect(resource.Properties.Integration.Credentials).to.be.equal('roleArn')
   })
+
+  it('should set RequestParameters to acceptParameters when configured', () => {
+    serverlessApigatewayServiceProxy.validated = {
+      events: [
+        {
+          serviceName: 'sqs',
+          http: {
+            queueName: 'myQueue',
+            path: 'sqs',
+            method: 'post',
+            auth: {
+              authorizationType: 'NONE'
+            },
+            acceptParameters: { 'method.request.header.Custom-Header': true }
+          }
+        }
+      ]
+    }
+    serverlessApigatewayServiceProxy.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi'
+    serverlessApigatewayServiceProxy.apiGatewayResources = {
+      sqs: {
+        name: 'sqs',
+        resourceLogicalId: 'ApiGatewayResourceSqs'
+      }
+    }
+
+    serverlessApigatewayServiceProxy.compileMethodsToSqs()
+
+    expect(
+      serverless.service.provider.compiledCloudFormationTemplate.Resources.ApiGatewayMethodsqsPost
+        .Properties.RequestParameters
+    ).to.be.deep.equal({ 'method.request.header.Custom-Header': true })
+  })
 })


### PR DESCRIPTION
Fixes #44 

@Vlaaaaaaad if you'd like to test it you can install directly from my branch:

```json
"dependencies": {
    ...
    "serverless-apigateway-service-proxy": "git://github.com/erezrokah/serverless-apigateway-service-proxy.git#feat/allow_passing_method_request_parameters"
  }
```
