### PR TITLE
Adding Dynamic Path Override

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,23 @@
-![serverless](http://public.serverless.com/badges/v3.svg)
-[![Build Status](https://travis-ci.org/horike37/serverless-apigateway-service-proxy.svg?branch=master)](https://travis-ci.org/horike37/serverless-apigateway-service-proxy) [![npm version](https://badge.fury.io/js/serverless-apigateway-service-proxy.svg)](https://badge.fury.io/js/serverless-apigateway-service-proxy) [![Coverage Status](https://coveralls.io/repos/github/horike37/serverless-apigateway-service-proxy/badge.svg?branch=master)](https://coveralls.io/github/horike37/serverless-apigateway-service-proxy?branch=master) [![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE)
+[![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE)
 
 # Serverless APIGateway Service Proxy
 
 This Serverless Framework plugin supports the AWS service proxy integration feature of API Gateway. You can directly connect API Gateway to AWS services without Lambda.
+In addition this fork support customized Path overrides to cater more specialized use cases.
 
 ## Install
 
-Run `serverless plugin install` in your Serverless project.
+Run `yarn add @hans_seek/serverless-apigateway-service-proxy` to install the plugin
 
 ```bash
-serverless plugin install -n @hans_seek/serverless-apigateway-service-proxy
+yarn add @hans_seek/serverless-apigateway-service-proxy
 ```
 
-Alternative run (if previous fails) `yarn add @hans_seek/serverless-apigateway-service-proxy`
+Or if using NPM:
+
+```bash
+npm i @hans_seek/serverless-apigateway-service-proxy --save
+```
 
 ## Supported AWS services
 
@@ -26,6 +30,13 @@ Please pull request if you are intersted in it.
 - SNS
 
 ## How to use
+
+Add the Plugin to your `serverless.yml`
+
+```yaml
+plugins:
+  - '@hans_seek/serverless-apigateway-service-proxy'
+```
 
 Define settings of the AWS services you want to integrate under `custom > apiGatewayServiceProxies` and run `serverless deploy`.
 
@@ -198,6 +209,38 @@ custom:
           'integration.request.path.object': 'context.requestId'
           'integration.request.header.cache-control': "'public, max-age=31536000, immutable'"
 ```
+
+#### Customize the Path Override in API Gateway
+
+Added the new customization parameter that lets the user set a custom Path Override in API Gateway other than the `{bucket}/{object}`
+This parameter is optional and if not set, will fall back to `{bucket}/{object}`
+The Path Override will add `{bucket}/` automatically in front
+
+Please keep in mind, that key or path.object still needs to be set at the moment (maybe this will be made optional later on with this)
+
+Usage (With 2 Path Parameters (folder and file and a fixed file extension)):
+
+```yaml
+custom:
+  apiGatewayServiceProxies:
+    - s3:
+        path: /s3/{folder}/{file}
+        method: get
+        action: GetObject
+        pathoverride: '{folder}/{file}.xml'
+        bucket:
+          Ref: S3Bucket
+        cors: true
+
+        requestParameters:
+          # if requestParameters has a 'integration.request.path.object' property you should remove the key setting
+          'integration.request.path.folder': 'method.request.path.folder'
+          'integration.request.path.file': 'method.request.path.file'
+          'integration.request.path.object': 'context.requestId'
+          'integration.request.header.cache-control': "'public, max-age=31536000, immutable'"
+```
+This will result in API Gateway setting the Path Override attribute to `{bucket}/{folder}/{file}.xml`
+So for example if you navigate to the API Gatway endpoint `/language/en` it will fetch the file in S3 from `{bucket}/language/en.xml`
 
 ### SNS
 

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ custom:
         path: /s3/{folder}/{file}
         method: get
         action: GetObject
-        pathoverride: '{folder}/{file}.xml'
+        pathOverride: '{folder}/{file}.xml'
         bucket:
           Ref: S3Bucket
         cors: true
@@ -228,6 +228,30 @@ custom:
 ```
 This will result in API Gateway setting the Path Override attribute to `{bucket}/{folder}/{file}.xml`
 So for example if you navigate to the API Gatway endpoint `/language/en` it will fetch the file in S3 from `{bucket}/language/en.xml`
+
+##### Can use greedy, for deeper Folders
+The forementioned example can also be shortened by a greedy approach. Thanks to @taylorreece for mentioning this.
+
+```yaml
+custom:
+  apiGatewayServiceProxies:
+    - s3:
+        path: /s3/{myPath+}
+        method: get
+        action: GetObject
+        pathOverride: '{myPath}.xml'
+        bucket:
+          Ref: S3Bucket
+        cors: true
+
+        requestParameters:
+          # if requestParameters has a 'integration.request.path.object' property you should remove the key setting
+          'integration.request.path.myPath': 'method.request.path.myPath'
+          'integration.request.path.object': 'context.requestId'
+          'integration.request.header.cache-control': "'public, max-age=31536000, immutable'"
+```
+
+This will translate for example `/s3/a/b/c` to `a/b/c.xml`
 
 ### SNS
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ This Serverless Framework plugin supports the AWS service proxy integration feat
 Run `serverless plugin install` in your Serverless project.
 
 ```bash
-serverless plugin install -n serverless-apigateway-service-proxy
+serverless plugin install -n @hans_seek/serverless-apigateway-service-proxy
 ```
+
+Alternative run (if previous fails) `yarn add @hans_seek/serverless-apigateway-service-proxy`
 
 ## Supported AWS services
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,16 @@
-[![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE)
+![serverless](http://public.serverless.com/badges/v3.svg)
+[![Build Status](https://travis-ci.org/horike37/serverless-apigateway-service-proxy.svg?branch=master)](https://travis-ci.org/horike37/serverless-apigateway-service-proxy) [![npm version](https://badge.fury.io/js/serverless-apigateway-service-proxy.svg)](https://badge.fury.io/js/serverless-apigateway-service-proxy) [![Coverage Status](https://coveralls.io/repos/github/horike37/serverless-apigateway-service-proxy/badge.svg?branch=master)](https://coveralls.io/github/horike37/serverless-apigateway-service-proxy?branch=master) [![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE)
 
 # Serverless APIGateway Service Proxy
 
 This Serverless Framework plugin supports the AWS service proxy integration feature of API Gateway. You can directly connect API Gateway to AWS services without Lambda.
-In addition this fork support customized Path overrides to cater more specialized use cases.
 
 ## Install
 
-Run `yarn add @hans_seek/serverless-apigateway-service-proxy` to install the plugin
+Run `serverless plugin install` in your Serverless project.
 
 ```bash
-yarn add @hans_seek/serverless-apigateway-service-proxy
-```
-
-Or if using NPM:
-
-```bash
-npm i @hans_seek/serverless-apigateway-service-proxy --save
+serverless plugin install -n serverless-apigateway-service-proxy
 ```
 
 ## Supported AWS services
@@ -30,13 +24,6 @@ Please pull request if you are intersted in it.
 - SNS
 
 ## How to use
-
-Add the Plugin to your `serverless.yml`
-
-```yaml
-plugins:
-  - '@hans_seek/serverless-apigateway-service-proxy'
-```
 
 Define settings of the AWS services you want to integrate under `custom > apiGatewayServiceProxies` and run `serverless deploy`.
 

--- a/lib/apiGateway/schema.js
+++ b/lib/apiGateway/schema.js
@@ -91,9 +91,6 @@ const roleArn = stringOrGetAtt('roleArn', 'Arn')
 
 const acceptParameters = Joi.object().pattern(Joi.string(), Joi.boolean().required())
 
-/**
- * Changes for dynamic Path Override
- */
 const pathoverride = Joi.string()
 
 const proxy = Joi.object({

--- a/lib/apiGateway/schema.js
+++ b/lib/apiGateway/schema.js
@@ -91,11 +91,11 @@ const roleArn = stringOrGetAtt('roleArn', 'Arn')
 
 const acceptParameters = Joi.object().pattern(Joi.string(), Joi.boolean().required())
 
-const pathoverride = Joi.string()
+const pathOverride = Joi.string()
 
 const proxy = Joi.object({
   path,
-  pathoverride,
+  pathOverride,
   method,
   cors,
   authorizationType,

--- a/lib/apiGateway/schema.js
+++ b/lib/apiGateway/schema.js
@@ -91,8 +91,14 @@ const roleArn = stringOrGetAtt('roleArn', 'Arn')
 
 const acceptParameters = Joi.object().pattern(Joi.string(), Joi.boolean().required())
 
+/**
+ * Changes for dynamic Path Override
+ */
+const pathoverride = Joi.string()
+
 const proxy = Joi.object({
   path,
+  pathoverride,
   method,
   cors,
   authorizationType,

--- a/lib/package/s3/compileMethodsToS3.js
+++ b/lib/package/s3/compileMethodsToS3.js
@@ -142,9 +142,6 @@ module.exports = {
       'Fn::GetAtt': ['ApigatewayToS3Role', 'Arn']
     }
 
-    /**
-     * Dynamic Path Override
-     */
     let pather = '{bucket}/{object}'
 
     if (_.has(http, 'pathoverride')) {

--- a/lib/package/s3/compileMethodsToS3.js
+++ b/lib/package/s3/compileMethodsToS3.js
@@ -142,12 +142,21 @@ module.exports = {
       'Fn::GetAtt': ['ApigatewayToS3Role', 'Arn']
     }
 
+    /**
+     * Dynamic Path Override
+     */
+    let pather = '{bucket}/{object}'
+
+    if (_.has(http, 'pathoverride')) {
+      pather = '{bucket}/' + http.pathoverride
+    }
+
     const integration = {
       IntegrationHttpMethod: httpMethod,
       Type: 'AWS',
       Credentials: roleArn,
       Uri: {
-        'Fn::Sub': ['arn:aws:apigateway:${AWS::Region}:s3:path/{bucket}/{object}', {}]
+        'Fn::Sub': ['arn:aws:apigateway:${AWS::Region}:s3:path/' + pather, {}]
       },
       PassthroughBehavior: 'WHEN_NO_MATCH',
       RequestParameters: _.merge(requestParams, http.requestParameters)

--- a/lib/package/s3/compileMethodsToS3.js
+++ b/lib/package/s3/compileMethodsToS3.js
@@ -144,8 +144,8 @@ module.exports = {
 
     let pather = '{bucket}/{object}'
 
-    if (_.has(http, 'pathoverride')) {
-      pather = '{bucket}/' + http.pathoverride
+    if (_.has(http, 'pathOverride')) {
+      pather = '{bucket}/' + http.pathOverride
     }
 
     const integration = {

--- a/lib/package/s3/compileMethodsToS3.test.js
+++ b/lib/package/s3/compileMethodsToS3.test.js
@@ -697,7 +697,7 @@ describe('#compileMethodsToS3()', () => {
             key: {
               pathParam: 'item'
             },
-            pathoverride: '{folder}/{item}.xml',
+            pathOverride: '{folder}/{item}.xml',
             auth: { authorizationType: 'NONE' },
             requestParameters: {
               'integration.request.path.folder': 'method.request.path.folder',
@@ -756,6 +756,124 @@ describe('#compileMethodsToS3()', () => {
               'integration.request.path.object': 'method.request.path.item',
               'integration.request.path.folder': 'method.request.path.folder',
               'integration.request.path.item': 'method.request.path.item'
+            },
+            IntegrationResponses: [
+              {
+                StatusCode: 400,
+                SelectionPattern: '4\\d{2}',
+                ResponseParameters: {},
+                ResponseTemplates: {}
+              },
+              {
+                StatusCode: 500,
+                SelectionPattern: '5\\d{2}',
+                ResponseParameters: {},
+                ResponseTemplates: {}
+              },
+              {
+                StatusCode: 200,
+                SelectionPattern: '2\\d{2}',
+                ResponseParameters: {
+                  'method.response.header.Content-Type': 'integration.response.header.Content-Type',
+                  'method.response.header.content-type': 'integration.response.header.content-type'
+                },
+                ResponseTemplates: {}
+              }
+            ]
+          },
+          MethodResponses: [
+            {
+              ResponseParameters: {
+                'method.response.header.Content-Type': true,
+                'method.response.header.content-type': true
+              },
+              ResponseModels: {},
+              StatusCode: 200
+            },
+            {
+              ResponseParameters: {},
+              ResponseModels: {},
+              StatusCode: 400
+            },
+            {
+              ResponseParameters: {},
+              ResponseModels: {},
+              StatusCode: 500
+            }
+          ]
+        }
+      }
+    })
+  })
+
+  it('should create corresponding resources when s3 GetObject proxy is given with a greedy path override', () => {
+    serverlessApigatewayServiceProxy.validated = {
+      events: [
+        {
+          serviceName: 's3',
+          http: {
+            path: '/{myPath+}',
+            method: 'get',
+            bucket: {
+              Ref: 'MyBucket'
+            },
+            action: 'GetObject',
+            key: {
+              pathParam: 'myPath'
+            },
+            pathOverride: '{myPath}.xml',
+            auth: { authorizationType: 'NONE' },
+            requestParameters: {
+              'integration.request.path.myPath': 'method.request.path.myPath'
+            }
+          }
+        }
+      ]
+    }
+    serverlessApigatewayServiceProxy.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi'
+    serverlessApigatewayServiceProxy.apiGatewayResources = {
+      '/{myPath+}': {
+        name: 'greedyPath',
+        resourceLogicalId: 'ApiGatewayPathOverrideS3'
+      }
+    }
+
+    serverlessApigatewayServiceProxy.compileMethodsToS3()
+    expect(serverless.service.provider.compiledCloudFormationTemplate.Resources).to.deep.equal({
+      ApiGatewayMethodgreedyPathGet: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'GET',
+          RequestParameters: {
+            'method.request.path.myPath': true
+          },
+          AuthorizationType: 'NONE',
+          AuthorizationScopes: undefined,
+          AuthorizerId: undefined,
+          ApiKeyRequired: false,
+          ResourceId: { Ref: 'ApiGatewayPathOverrideS3' },
+          RestApiId: { Ref: 'ApiGatewayRestApi' },
+          Integration: {
+            Type: 'AWS',
+            IntegrationHttpMethod: 'GET',
+            Credentials: { 'Fn::GetAtt': ['ApigatewayToS3Role', 'Arn'] },
+            Uri: {
+              'Fn::Sub': ['arn:aws:apigateway:${AWS::Region}:s3:path/{bucket}/{myPath}.xml', {}]
+            },
+            PassthroughBehavior: 'WHEN_NO_MATCH',
+            RequestParameters: {
+              'integration.request.path.bucket': {
+                'Fn::Sub': [
+                  "'${bucket}'",
+                  {
+                    bucket: {
+                      Ref: 'MyBucket'
+                    }
+                  }
+                ]
+              },
+              'integration.request.path.object': 'method.request.path.myPath',
+              'integration.request.path.myPath': 'method.request.path.myPath'
             },
             IntegrationResponses: [
               {

--- a/lib/package/s3/compileMethodsToS3.test.js
+++ b/lib/package/s3/compileMethodsToS3.test.js
@@ -681,4 +681,128 @@ describe('#compileMethodsToS3()', () => {
       'method.request.path.key': true
     })
   })
+
+  it('should create corresponding resources when s3 GetObject proxy is given with path override', () => {
+    serverlessApigatewayServiceProxy.validated = {
+      events: [
+        {
+          serviceName: 's3',
+          http: {
+            path: '/{folder}/{item}',
+            method: 'get',
+            bucket: {
+              Ref: 'MyBucket'
+            },
+            action: 'GetObject',
+            key: {
+              pathParam: 'item'
+            },
+            pathoverride: '{folder}/{item}.xml',
+            auth: { authorizationType: 'NONE' },
+            requestParameters: {
+              'integration.request.path.folder': 'method.request.path.folder',
+              'integration.request.path.item': 'method.request.path.item'
+            }
+          }
+        }
+      ]
+    }
+    serverlessApigatewayServiceProxy.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi'
+    serverlessApigatewayServiceProxy.apiGatewayResources = {
+      '/{folder}/{item}': {
+        name: 'po',
+        resourceLogicalId: 'ApiGatewayPathOverrideS3'
+      }
+    }
+
+    serverlessApigatewayServiceProxy.compileMethodsToS3()
+    expect(serverless.service.provider.compiledCloudFormationTemplate.Resources).to.deep.equal({
+      ApiGatewayMethodpoGet: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'GET',
+          RequestParameters: {
+            'method.request.path.folder': true,
+            'method.request.path.item': true
+          },
+          AuthorizationType: 'NONE',
+          AuthorizationScopes: undefined,
+          AuthorizerId: undefined,
+          ApiKeyRequired: false,
+          ResourceId: { Ref: 'ApiGatewayPathOverrideS3' },
+          RestApiId: { Ref: 'ApiGatewayRestApi' },
+          Integration: {
+            Type: 'AWS',
+            IntegrationHttpMethod: 'GET',
+            Credentials: { 'Fn::GetAtt': ['ApigatewayToS3Role', 'Arn'] },
+            Uri: {
+              'Fn::Sub': [
+                'arn:aws:apigateway:${AWS::Region}:s3:path/{bucket}/{folder}/{item}.xml',
+                {}
+              ]
+            },
+            PassthroughBehavior: 'WHEN_NO_MATCH',
+            RequestParameters: {
+              'integration.request.path.bucket': {
+                'Fn::Sub': [
+                  "'${bucket}'",
+                  {
+                    bucket: {
+                      Ref: 'MyBucket'
+                    }
+                  }
+                ]
+              },
+              'integration.request.path.object': 'method.request.path.item',
+              'integration.request.path.folder': 'method.request.path.folder',
+              'integration.request.path.item': 'method.request.path.item'
+            },
+            IntegrationResponses: [
+              {
+                StatusCode: 400,
+                SelectionPattern: '4\\d{2}',
+                ResponseParameters: {},
+                ResponseTemplates: {}
+              },
+              {
+                StatusCode: 500,
+                SelectionPattern: '5\\d{2}',
+                ResponseParameters: {},
+                ResponseTemplates: {}
+              },
+              {
+                StatusCode: 200,
+                SelectionPattern: '2\\d{2}',
+                ResponseParameters: {
+                  'method.response.header.Content-Type': 'integration.response.header.Content-Type',
+                  'method.response.header.content-type': 'integration.response.header.content-type'
+                },
+                ResponseTemplates: {}
+              }
+            ]
+          },
+          MethodResponses: [
+            {
+              ResponseParameters: {
+                'method.response.header.Content-Type': true,
+                'method.response.header.content-type': true
+              },
+              ResponseModels: {},
+              StatusCode: 200
+            },
+            {
+              ResponseParameters: {},
+              ResponseModels: {},
+              StatusCode: 400
+            },
+            {
+              ResponseParameters: {},
+              ResponseModels: {},
+              StatusCode: 500
+            }
+          ]
+        }
+      }
+    })
+  })
 })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@hans_seek/serverless-apigateway-service-proxy",
-  "version": "1.3.1",
-  "description": "This is a fork of https://www.npmjs.com/package/serverless-apigateway-service-proxy. The Serverless Framewrok plugin for supporting AWS service proxy integration of API Gateway",
+  "name": "serverless-apigateway-service-proxy",
+  "version": "1.3.0",
+  "description": "The Serverless Framewrok plugin for supporting AWS service proxy integration of API Gateway",
   "main": "lib/index.js",
   "scripts": {
     "lint": "eslint .",
@@ -31,7 +31,7 @@
       "<rootDir>/__tests__/setup-tests.js"
     ]
   },
-  "author": "Hans Roessler",
+  "author": "horike37",
   "license": "MIT",
   "devDependencies": {
     "@commitlint/cli": "^8.1.0",
@@ -61,6 +61,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Hans-Seek/serverless-apigateway-service-proxy.git"
+    "url": "https://github.com/horike37/serverless-apigateway-service-proxy.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "serverless-apigateway-service-proxy",
-  "version": "1.3.0",
-  "description": "The Serverless Framewrok plugin for supporting AWS service proxy integration of API Gateway",
+  "name": "@hans_seek/serverless-apigateway-service-proxy",
+  "version": "1.3.1",
+  "description": "This is a fork of https://www.npmjs.com/package/serverless-apigateway-service-proxy. The Serverless Framewrok plugin for supporting AWS service proxy integration of API Gateway",
   "main": "lib/index.js",
   "scripts": {
     "lint": "eslint .",
@@ -31,7 +31,7 @@
       "<rootDir>/__tests__/setup-tests.js"
     ]
   },
-  "author": "horike37",
+  "author": "Hans Roessler",
   "license": "MIT",
   "devDependencies": {
     "@commitlint/cli": "^8.1.0",
@@ -61,6 +61,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/horike37/serverless-apigateway-service-proxy.git"
+    "url": "https://github.com/Hans-Seek/serverless-apigateway-service-proxy.git"
   }
 }


### PR DESCRIPTION
We recently faced a problem with the serverless proxy integration, namely when the s3 has a couple of folders and the folders should be mapped via path parameters. We found out that the solution to this would be to slightly adjust this plugin (by making the path override dynamic with fallback to the default functionality)

The main change was made in `lib/package/s3/compileMethodsToS3.js`:

```js
    let pather = '{bucket}/{object}'

    if (_.has(http, 'pathoverride')) {
      pather = '{bucket}/' + http.pathoverride
    }

    const integration = {
      IntegrationHttpMethod: httpMethod,
      Type: 'AWS',
      Credentials: roleArn,
      Uri: {
        'Fn::Sub': ['arn:aws:apigateway:${AWS::Region}:s3:path/' + pather, {}]
      },
      PassthroughBehavior: 'WHEN_NO_MATCH',
      RequestParameters: _.merge(requestParams, http.requestParameters)
    }
```

This will allow paths like `{folder}/{subfolder}/{item}` to be mapped to an s3 endpoint like for example `{folder}/{subfolder}/{item}.xml`

For example if the API Gateway gets called with `function/english/data` it will look for the file in s3 at the following point: `{bucket}/function/english/data.xml`

It can easily be adjusted via `serverless.yml` by adding the pathoverride attribute (string) to a s3 object. I also added these details into the `Readme.md` into the S3 section. Please let me know about your thoughts and also let me know if anything needs to be changed/verified before it could be considered to be merged into the plugin. 