### PR TITLE
Allow s3 service users to prefix s3 objects with a path

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,17 @@ custom:
         key:
           queryStringParam: key # use query string param
         cors: true
+    
+    - s3:
+        path: /s3/{myKey}
+        method: get
+        action: GetObject
+        objectPrefix: path/to/my/object # Look for s3://{S3Bucket}/path/to/my/object/{myKey}
+        bucket:
+          Ref: S3Bucket
+        key:
+          pathParam: myKey
+        cors: true
 
 resources:
   Resources:

--- a/lib/apiGateway/schema.js
+++ b/lib/apiGateway/schema.js
@@ -163,6 +163,7 @@ const proxiesSchemas = {
         .valid('GetObject', 'PutObject', 'DeleteObject')
         .required(),
       bucket: stringOrRef.required(),
+      objectPrefix: Joi.string(),
       // don't accept a key when requestParameters has a 'integration.request.path.object' property
       key: Joi.when('requestParameters', {
         is: requestParameters

--- a/lib/package/s3/compileMethodsToS3.js
+++ b/lib/package/s3/compileMethodsToS3.js
@@ -129,6 +129,16 @@ module.exports = {
       }
     })
 
+    if (http.objectPrefix) {
+      requestParams = _.merge(requestParams, {
+        'integration.request.path.objectPrefix': `'${http.objectPrefix}'`
+      })
+    }
+
+    let bucketObjectArn = http.objectPrefix ? 
+      'arn:aws:apigateway:${AWS::Region}:s3:path/{bucket}/{objectPrefix}/{object}'
+      : 'arn:aws:apigateway:${AWS::Region}:s3:path/{bucket}/{object}'
+
     if (_.has(http, 'key')) {
       const objectRequestParam = this.getObjectRequestParameter(http)
       requestParams = _.merge(requestParams, {
@@ -147,7 +157,7 @@ module.exports = {
       Type: 'AWS',
       Credentials: roleArn,
       Uri: {
-        'Fn::Sub': ['arn:aws:apigateway:${AWS::Region}:s3:path/{bucket}/{object}', {}]
+        'Fn::Sub': [bucketObjectArn, {}]
       },
       PassthroughBehavior: 'WHEN_NO_MATCH',
       RequestParameters: _.merge(requestParams, http.requestParameters)

--- a/lib/package/s3/compileMethodsToS3.js
+++ b/lib/package/s3/compileMethodsToS3.js
@@ -135,8 +135,8 @@ module.exports = {
       })
     }
 
-    const bucketObjectArn = http.objectPrefix ?
-      'arn:aws:apigateway:${AWS::Region}:s3:path/{bucket}/{objectPrefix}/{object}'
+    const bucketObjectArn = http.objectPrefix
+      ? 'arn:aws:apigateway:${AWS::Region}:s3:path/{bucket}/{objectPrefix}/{object}'
       : 'arn:aws:apigateway:${AWS::Region}:s3:path/{bucket}/{object}'
 
     if (_.has(http, 'key')) {

--- a/lib/package/s3/compileMethodsToS3.js
+++ b/lib/package/s3/compileMethodsToS3.js
@@ -135,7 +135,7 @@ module.exports = {
       })
     }
 
-    let bucketObjectArn = http.objectPrefix ? 
+    const bucketObjectArn = http.objectPrefix ?
       'arn:aws:apigateway:${AWS::Region}:s3:path/{bucket}/{objectPrefix}/{object}'
       : 'arn:aws:apigateway:${AWS::Region}:s3:path/{bucket}/{object}'
 


### PR DESCRIPTION
I have an S3 bucket with objects in sub-directories of the bucket, and had trouble finding a way to proxy calls to S3 subdirectories properly.  Specifically, I'm putting a compiled react app in an S3 bucket, and the statically compiled JS, CSS, assets, etc look like
```
s3://my-bucket/static/css/some-file-1234.css
s3://my-bucket/static/assets/an-image.jpeg
s3://my-bucket/static/js/some-file.js
s3://my-bucket/static/js/some-other-file-12345.js
```
However, if I defined an S3 proxy like this
```
- s3:
    path: /static/{object+}
    method: get
    action: GetObject
    bucket:
      Ref: ReactS3Bucket
    key:
      pathParam: object
    cors: true
```
a request to `http://my-endpoint/static/js/some-file.js` would have API Gateway looking into `s3://my-bucket/js/some-other-file-12345.js` without the `static`

I needed a way to prepend a path to the object key.  So... I did.  that's what this commit is.  For existing definitions things don't change, but if you have a `objectPrefix` property, it'll throw that value between the S3 bucket name, and the object key.

```
- s3:
    path: /static/{object+}
    method: get
    action: GetObject
    objectPrefix: static
    bucket:
      Ref: ReactS3Bucket
    key:
      pathParam: object
    cors: true
```

Please let me know if there's a better way to do this sort of thing.