### PR TITLE
fix(cognito_auth): allow setting authorizerId for cognito

### DIFF
--- a/lib/apiGateway/schema.js
+++ b/lib/apiGateway/schema.js
@@ -51,7 +51,7 @@ const authorizationScopes = Joi.array()
 const authorizationType = Joi.alternatives().when('authorizerId', {
   is: authorizerId.required(),
   then: Joi.string()
-    .valid('CUSTOM')
+    .valid('CUSTOM', 'COGNITO_USER_POOLS')
     .required(),
   otherwise: Joi.alternatives().when('authorizationScopes', {
     is: authorizationScopes.required(),
@@ -103,12 +103,7 @@ const proxy = Joi.object({
   authorizationScopes,
   roleArn,
   acceptParameters
-})
-  .oxor('authorizerId', 'authorizationScopes') // can have one of them, but not required
-  .error(
-    customErrorBuilder('object.oxor', 'cannot set both "authorizerId" and "authorizationScopes"')
-  )
-  .required()
+}).required()
 
 const stringOrRef = Joi.alternatives().try([
   Joi.string(),

--- a/lib/apiGateway/validate.test.js
+++ b/lib/apiGateway/validate.test.js
@@ -453,7 +453,7 @@ describe('#validateServiceProxies()', () => {
       )
     })
 
-    it('should throw if "authorizationType" is not set to "CUSTOM" when the "authorizerId" property is set', () => {
+    it('should throw if "authorizationType" is not set to "CUSTOM" or "COGNITO_USER_POOLS" when the "authorizerId" property is set', () => {
       serverlessApigatewayServiceProxy.serverless.service.custom = {
         apiGatewayServiceProxies: [
           {
@@ -470,7 +470,7 @@ describe('#validateServiceProxies()', () => {
 
       expect(() => serverlessApigatewayServiceProxy.validateServiceProxies()).to.throw(
         serverless.classes.Error,
-        'child "kinesis" fails because [child "authorizationType" fails because ["authorizationType" must be one of [CUSTOM]]]'
+        'child "kinesis" fails because [child "authorizationType" fails because ["authorizationType" must be one of [CUSTOM, COGNITO_USER_POOLS]]]'
       )
     })
 
@@ -564,6 +564,7 @@ describe('#validateServiceProxies()', () => {
               path: '/kinesis',
               streamName: 'streamName',
               authorizationType: 'COGNITO_USER_POOLS',
+              authorizerId: { Ref: 'SomeAuthorizerId' },
               authorizationScopes: ['editor', 'owner'],
               method: 'post'
             }
@@ -575,6 +576,7 @@ describe('#validateServiceProxies()', () => {
 
       expect(json.events[0].http.auth).to.deep.equal({
         authorizationType: 'COGNITO_USER_POOLS',
+        authorizerId: { Ref: 'SomeAuthorizerId' },
         authorizationScopes: ['editor', 'owner']
       })
     })


### PR DESCRIPTION
Fixes https://github.com/horike37/serverless-apigateway-service-proxy/issues/51

See the end of the comment here https://github.com/horike37/serverless-apigateway-service-proxy/issues/51#issuecomment-556983282

On the reason `authorizerId` was disallowed for cognito until now.