### PR TITLE
fix: common-tags appears to be package dependency, not just a dev dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3610,8 +3610,7 @@
     "common-tags": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
-      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
-      "dev": true
+      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw=="
     },
     "compare-func": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     ]
   },
   "dependencies": {
+    "common-tags": "^1.8.0",
     "@hapi/joi": "^15.1.0",
     "serverless": "^1.48.2"
   },
@@ -40,7 +41,6 @@
     "aws-testing-library": "^1.0.8",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
-    "common-tags": "^1.8.0",
     "coveralls": "^3.0.5",
     "eslint": "^6.0.1",
     "eslint-config-prettier": "^6.0.0",


### PR DESCRIPTION
This fixes #57 .  common-tags isn't just a dev dependency, but needs to be installed as a dependency for users of your package.  

Thanks!