### PR TITLE
Allow Private Field

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ resources:
 
 which is the same syntax used in Serverless framework.
 
-Source: [Setting API keys for your Rest API](https://serverless.com/framework/docs/providers/aws/events/apigateway/#setting-api-keys-for-your-rest-api)
+Source: [Serverless: Setting API keys for your Rest API](https://serverless.com/framework/docs/providers/aws/events/apigateway/#setting-api-keys-for-your-rest-api)
 
 Source: [AWS::ApiGateway::Method docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-method.html#cfn-apigateway-method-apikeyrequired)
 

--- a/README.md
+++ b/README.md
@@ -480,6 +480,35 @@ resources:
 
 Source: [AWS::ApiGateway::Method docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-method.html#cfn-apigateway-method-authorizationtype)
 
+
+
+### Enabling API Token Authentication
+
+You can indicate whether the method requires clients to submit a valid API key using `private` flag:
+
+```yml
+custom:
+  apiGatewayServiceProxies:
+    - sqs:
+        path: /sqs
+        method: post
+        queueName: { 'Fn::GetAtt': ['SQSQueue', 'QueueName'] }
+        cors: true
+        private: true
+
+resources:
+  Resources:
+    SQSQueue:
+      Type: 'AWS::SQS::Queue'
+```
+
+which is the same syntax used in Serverless framework.
+
+Source: [Setting API keys for your Rest API](https://serverless.com/framework/docs/providers/aws/events/apigateway/#setting-api-keys-for-your-rest-api)
+
+Source: [AWS::ApiGateway::Method docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-method.html#cfn-apigateway-method-apikeyrequired)
+
+
 ### Using a Custom IAM Role
 
 By default, the plugin will generate a role with the required permissions for each service type that is configured.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This Serverless Framework plugin supports the AWS service proxy integration feat
 - [Common API Gateway features](#common-api-gateway-features)
   - [Enabling CORS](#enabling-cors)
   - [Adding Authorization](#adding-authorization)
+  - [Enabling API Token Authentication](#enabling-api-token-authentication)
   - [Using a Custom IAM Role](#using-a-custom-iam-role)
   - [Customizing API Gateway parameters](#customizing-api-gateway-parameters)
   - [Customizing request body mapping templates](#customizing-request-body-mapping-templates)

--- a/lib/apiGateway/schema.js
+++ b/lib/apiGateway/schema.js
@@ -23,6 +23,8 @@ const method = Joi.string()
   .valid(['get', 'post', 'put', 'patch', 'options', 'head', 'delete', 'any'])
   .insensitive()
 
+const privateField = Joi.boolean().default(false)
+
 const cors = Joi.alternatives().try(
   Joi.boolean(),
   Joi.object({
@@ -98,6 +100,7 @@ const proxy = Joi.object({
   pathOverride,
   method,
   cors,
+  private: privateField,
   authorizationType,
   authorizerId,
   authorizationScopes,

--- a/lib/apiGateway/validate.test.js
+++ b/lib/apiGateway/validate.test.js
@@ -137,6 +137,75 @@ describe('#validateServiceProxies()', () => {
       expect(() => serverlessApigatewayServiceProxy.validateServiceProxies()).to.not.throw()
     })
 
+    it('should work if "private" property is missing', () => {
+      serverlessApigatewayServiceProxy.serverless.service.custom = {
+        apiGatewayServiceProxies: [
+          {
+            kinesis: {
+              path: '/kinesis',
+              streamName: 'streamName',
+              method: 'POST'
+            }
+          }
+        ]
+      }
+
+      expect(() => serverlessApigatewayServiceProxy.validateServiceProxies()).to.not.throw()
+    })
+
+    it('should work if "private" property is true', () => {
+      serverlessApigatewayServiceProxy.serverless.service.custom = {
+        apiGatewayServiceProxies: [
+          {
+            kinesis: {
+              path: '/kinesis',
+              streamName: 'streamName',
+              method: 'POST',
+              private: true
+            }
+          }
+        ]
+      }
+
+      expect(() => serverlessApigatewayServiceProxy.validateServiceProxies()).to.not.throw()
+    })
+
+    it('should work if "private" property is false', () => {
+      serverlessApigatewayServiceProxy.serverless.service.custom = {
+        apiGatewayServiceProxies: [
+          {
+            kinesis: {
+              path: '/kinesis',
+              streamName: 'streamName',
+              method: 'POST',
+              private: false
+            }
+          }
+        ]
+      }
+
+      expect(() => serverlessApigatewayServiceProxy.validateServiceProxies()).to.not.throw()
+    })
+
+    it('should throw if "private" property is set to unsupported type', () => {
+      serverlessApigatewayServiceProxy.serverless.service.custom = {
+        apiGatewayServiceProxies: [
+          {
+            kinesis: {
+              path: '/kinesis',
+              streamName: 'streamName',
+              method: 'POST',
+              private: 'xxxxx'
+            }
+          }
+        ]
+      }
+      expect(() => serverlessApigatewayServiceProxy.validateServiceProxies()).to.throw(
+        serverless.classes.Error,
+        'child "kinesis" fails because [child "private" fails because ["private" must be a boolean]]'
+      )
+    })
+
     it('should process cors defaults', () => {
       serverlessApigatewayServiceProxy.serverless.service.custom = {
         apiGatewayServiceProxies: [

--- a/lib/package/dynamodb/compileMethodsToDynamodb.test.js
+++ b/lib/package/dynamodb/compileMethodsToDynamodb.test.js
@@ -825,6 +825,117 @@ describe('#compileMethodsToDynamodb()', () => {
       })
     })
   })
+
+  describe('#private', () => {
+    it('should create corresponding resources when a dynamodb proxy is given with private', () => {
+      serverlessApigatewayServiceProxy.validated = {
+        events: [
+          {
+            serviceName: 'dynamodb',
+            http: {
+              path: 'dynamodb',
+              method: 'post',
+              action: 'PutItem',
+              tableName: {
+                Ref: 'MyTable'
+              },
+              key: 'key',
+              private: true,
+              auth: { authorizationType: 'NONE' }
+            }
+          }
+        ]
+      }
+      serverlessApigatewayServiceProxy.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi'
+      serverlessApigatewayServiceProxy.apiGatewayResources = {
+        dynamodb: {
+          name: 'dynamodb',
+          resourceLogicalId: 'ApiGatewayResourceDynamodb'
+        }
+      }
+
+      serverlessApigatewayServiceProxy.compileMethodsToDynamodb()
+      expect(serverless.service.provider.compiledCloudFormationTemplate.Resources).to.deep.equal({
+        ApiGatewayMethoddynamodbPost: {
+          Type: 'AWS::ApiGateway::Method',
+          Properties: {
+            HttpMethod: 'POST',
+            RequestParameters: {},
+            AuthorizationScopes: undefined,
+            AuthorizerId: undefined,
+            AuthorizationType: 'NONE',
+            ApiKeyRequired: true,
+            ResourceId: { Ref: 'ApiGatewayResourceDynamodb' },
+            RestApiId: { Ref: 'ApiGatewayRestApi' },
+            Integration: {
+              IntegrationHttpMethod: 'POST',
+              Type: 'AWS',
+              Credentials: { 'Fn::GetAtt': ['ApigatewayToDynamodbRole', 'Arn'] },
+              Uri: {
+                'Fn::Sub': [
+                  'arn:aws:apigateway:${AWS::Region}:dynamodb:action/${action}',
+                  { action: 'PutItem' }
+                ]
+              },
+              PassthroughBehavior: 'NEVER',
+              RequestTemplates: {
+                'application/json': {
+                  'Fn::Sub': [
+                    '{"TableName": "${TableName}","Item": {\n      #set ($body = $util.parseJson($input.body))\n      #foreach( $key in $body.keySet())\n        #set ($item = $body.get($key))\n        #foreach( $type in $item.keySet())\n          "$key":{"$type" : "$item.get($type)"}\n        #if($foreach.hasNext()),#end\n        #end\n      #if($foreach.hasNext()),#end\n      #end\n    }\n    }',
+                    { TableName: { Ref: 'MyTable' } }
+                  ]
+                },
+                'application/x-www-form-urlencoded': {
+                  'Fn::Sub': [
+                    '{"TableName": "${TableName}","Item": {\n      #set ($body = $util.parseJson($input.body))\n      #foreach( $key in $body.keySet())\n        #set ($item = $body.get($key))\n        #foreach( $type in $item.keySet())\n          "$key":{"$type" : "$item.get($type)"}\n        #if($foreach.hasNext()),#end\n        #end\n      #if($foreach.hasNext()),#end\n      #end\n    }\n    }',
+                    { TableName: { Ref: 'MyTable' } }
+                  ]
+                }
+              },
+              IntegrationResponses: [
+                {
+                  StatusCode: 200,
+                  SelectionPattern: '2\\d{2}',
+                  ResponseParameters: {},
+                  ResponseTemplates: {}
+                },
+                {
+                  StatusCode: 400,
+                  SelectionPattern: '4\\d{2}',
+                  ResponseParameters: {},
+                  ResponseTemplates: {}
+                },
+                {
+                  StatusCode: 500,
+                  SelectionPattern: '5\\d{2}',
+                  ResponseParameters: {},
+                  ResponseTemplates: {}
+                }
+              ]
+            },
+            MethodResponses: [
+              {
+                ResponseParameters: {},
+                ResponseModels: {},
+                StatusCode: 200
+              },
+              {
+                ResponseParameters: {},
+                ResponseModels: {},
+                StatusCode: 400
+              },
+              {
+                ResponseParameters: {},
+                ResponseModels: {},
+                StatusCode: 500
+              }
+            ]
+          }
+        }
+      })
+    })
+  })
+
   describe('#authorization', () => {
     const testAuthorization = (auth) => {
       const param = {

--- a/lib/package/kinesis/compileMethodsToKinesis.test.js
+++ b/lib/package/kinesis/compileMethodsToKinesis.test.js
@@ -249,6 +249,118 @@ describe('#compileMethodsToKinesis()', () => {
     })
   })
 
+  it('should create corresponding resources when kinesis proxies are given with private', () => {
+    serverlessApigatewayServiceProxy.validated = {
+      events: [
+        {
+          serviceName: 'kinesis',
+          http: {
+            streamName: 'myStream',
+            path: 'kinesis',
+            method: 'post',
+            auth: {
+              authorizationType: 'NONE'
+            },
+            private: true
+          }
+        }
+      ]
+    }
+    serverlessApigatewayServiceProxy.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi'
+    serverlessApigatewayServiceProxy.apiGatewayResources = {
+      kinesis: {
+        name: 'kinesis',
+        resourceLogicalId: 'ApiGatewayResourceKinesis'
+      }
+    }
+
+    serverlessApigatewayServiceProxy.compileMethodsToKinesis()
+
+    expect(serverless.service.provider.compiledCloudFormationTemplate.Resources).to.deep.equal({
+      ApiGatewayMethodkinesisPost: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'POST',
+          RequestParameters: {},
+          AuthorizationType: 'NONE',
+          AuthorizerId: undefined,
+          AuthorizationScopes: undefined,
+          ApiKeyRequired: true,
+          ResourceId: { Ref: 'ApiGatewayResourceKinesis' },
+          RestApiId: { Ref: 'ApiGatewayRestApi' },
+          Integration: {
+            IntegrationHttpMethod: 'POST',
+            Type: 'AWS',
+            Credentials: { 'Fn::GetAtt': ['ApigatewayToKinesisRole', 'Arn'] },
+            Uri: {
+              'Fn::Sub': 'arn:aws:apigateway:${AWS::Region}:kinesis:action/PutRecord'
+            },
+            PassthroughBehavior: 'NEVER',
+            RequestTemplates: {
+              'application/json': {
+                'Fn::Sub': [
+                  '{"StreamName":"${StreamName}","Data":"${Data}","PartitionKey":"${PartitionKey}"}',
+                  {
+                    StreamName: 'myStream',
+                    Data: '$util.base64Encode($input.body)',
+                    PartitionKey: '$context.requestId'
+                  }
+                ]
+              },
+              'application/x-www-form-urlencoded': {
+                'Fn::Sub': [
+                  '{"StreamName":"${StreamName}","Data":"${Data}","PartitionKey":"${PartitionKey}"}',
+                  {
+                    StreamName: 'myStream',
+                    Data: '$util.base64Encode($input.body)',
+                    PartitionKey: '$context.requestId'
+                  }
+                ]
+              }
+            },
+            IntegrationResponses: [
+              {
+                StatusCode: 200,
+                SelectionPattern: 200,
+                ResponseParameters: {},
+                ResponseTemplates: {}
+              },
+              {
+                StatusCode: 400,
+                SelectionPattern: 400,
+                ResponseParameters: {},
+                ResponseTemplates: {}
+              },
+              {
+                StatusCode: 500,
+                SelectionPattern: 500,
+                ResponseParameters: {},
+                ResponseTemplates: {}
+              }
+            ]
+          },
+          MethodResponses: [
+            {
+              ResponseParameters: {},
+              ResponseModels: {},
+              StatusCode: 200
+            },
+            {
+              ResponseParameters: {},
+              ResponseModels: {},
+              StatusCode: 400
+            },
+            {
+              ResponseParameters: {},
+              ResponseModels: {},
+              StatusCode: 500
+            }
+          ]
+        }
+      }
+    })
+  })
+
   it('should return the default template for application/json when one is not given', () => {
     const httpWithoutRequestTemplate = {
       path: 'foo/bar1',

--- a/lib/package/s3/compileMethodsToS3.test.js
+++ b/lib/package/s3/compileMethodsToS3.test.js
@@ -472,6 +472,124 @@ describe('#compileMethodsToS3()', () => {
     })
   })
 
+  it('should create corresponding resources when a s3 proxy is given with private', () => {
+    serverlessApigatewayServiceProxy.validated = {
+      events: [
+        {
+          serviceName: 's3',
+          http: {
+            path: 's3',
+            method: 'post',
+            bucket: {
+              Ref: 'MyBucket'
+            },
+            action: 'PutObject',
+            key: {
+              pathParam: 'key'
+            },
+            private: true,
+            auth: { authorizationType: 'NONE' }
+          }
+        }
+      ]
+    }
+    serverlessApigatewayServiceProxy.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi'
+    serverlessApigatewayServiceProxy.apiGatewayResources = {
+      s3: {
+        name: 's3',
+        resourceLogicalId: 'ApiGatewayResourceS3'
+      }
+    }
+
+    serverlessApigatewayServiceProxy.compileMethodsToS3()
+    expect(serverless.service.provider.compiledCloudFormationTemplate.Resources).to.deep.equal({
+      ApiGatewayMethods3Post: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'POST',
+          RequestParameters: {
+            'method.request.header.Content-Type': true,
+            'method.request.path.key': true
+          },
+          AuthorizationType: 'NONE',
+          AuthorizationScopes: undefined,
+          AuthorizerId: undefined,
+          ApiKeyRequired: true,
+          ResourceId: { Ref: 'ApiGatewayResourceS3' },
+          RestApiId: { Ref: 'ApiGatewayRestApi' },
+          Integration: {
+            Type: 'AWS',
+            IntegrationHttpMethod: 'PUT',
+            Credentials: { 'Fn::GetAtt': ['ApigatewayToS3Role', 'Arn'] },
+            Uri: {
+              'Fn::Sub': ['arn:aws:apigateway:${AWS::Region}:s3:path/{bucket}/{object}', {}]
+            },
+            PassthroughBehavior: 'WHEN_NO_MATCH',
+            RequestParameters: {
+              'integration.request.header.Content-Type': 'method.request.header.Content-Type',
+              'integration.request.header.x-amz-acl': "'authenticated-read'",
+              'integration.request.path.bucket': {
+                'Fn::Sub': [
+                  "'${bucket}'",
+                  {
+                    bucket: {
+                      Ref: 'MyBucket'
+                    }
+                  }
+                ]
+              },
+              'integration.request.path.object': 'method.request.path.key'
+            },
+            IntegrationResponses: [
+              {
+                StatusCode: 400,
+                SelectionPattern: '4\\d{2}',
+                ResponseParameters: {},
+                ResponseTemplates: {}
+              },
+              {
+                StatusCode: 500,
+                SelectionPattern: '5\\d{2}',
+                ResponseParameters: {},
+                ResponseTemplates: {}
+              },
+              {
+                StatusCode: 200,
+                SelectionPattern: '2\\d{2}',
+                ResponseParameters: {
+                  'method.response.header.Content-Type': 'integration.response.header.Content-Type',
+                  'method.response.header.Content-Length':
+                    'integration.response.header.Content-Length'
+                },
+                ResponseTemplates: {}
+              }
+            ]
+          },
+          MethodResponses: [
+            {
+              ResponseParameters: {
+                'method.response.header.Content-Type': true,
+                'method.response.header.Content-Length': true
+              },
+              ResponseModels: {},
+              StatusCode: 200
+            },
+            {
+              ResponseParameters: {},
+              ResponseModels: {},
+              StatusCode: 400
+            },
+            {
+              ResponseParameters: {},
+              ResponseModels: {},
+              StatusCode: 500
+            }
+          ]
+        }
+      }
+    })
+  })
+
   const testAuthorization = (auth) => {
     const http = {
       path: 's3',

--- a/lib/package/sns/compileMethodsToSns.test.js
+++ b/lib/package/sns/compileMethodsToSns.test.js
@@ -275,6 +275,131 @@ describe('#compileMethodsToSns()', () => {
     })
   })
 
+  it('should create corresponding resources when sns proxies are given with private', () => {
+    serverlessApigatewayServiceProxy.validated = {
+      events: [
+        {
+          serviceName: 'sns',
+          http: {
+            topicName: 'myTopic',
+            path: 'sns',
+            method: 'post',
+            auth: {
+              authorizationType: 'NONE'
+            },
+            private: true
+          }
+        }
+      ]
+    }
+    serverlessApigatewayServiceProxy.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi'
+    serverlessApigatewayServiceProxy.apiGatewayResources = {
+      sns: {
+        name: 'Sns',
+        resourceLogicalId: 'ApiGatewayResourceSns'
+      }
+    }
+
+    serverlessApigatewayServiceProxy.compileMethodsToSns()
+
+    expect(serverless.service.provider.compiledCloudFormationTemplate.Resources).to.deep.equal({
+      ApiGatewayMethodSnsPost: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'POST',
+          RequestParameters: {},
+          AuthorizationType: 'NONE',
+          AuthorizerId: undefined,
+          AuthorizationScopes: undefined,
+          ApiKeyRequired: true,
+          ResourceId: { Ref: 'ApiGatewayResourceSns' },
+          RestApiId: { Ref: 'ApiGatewayRestApi' },
+          Integration: {
+            IntegrationHttpMethod: 'POST',
+            Type: 'AWS',
+            Credentials: { 'Fn::GetAtt': ['ApigatewayToSnsRole', 'Arn'] },
+            Uri: {
+              'Fn::Sub': 'arn:aws:apigateway:${AWS::Region}:sns:path//'
+            },
+            PassthroughBehavior: 'NEVER',
+            RequestParameters: {
+              'integration.request.header.Content-Type': "'application/x-www-form-urlencoded'"
+            },
+            RequestTemplates: {
+              'application/json': {
+                'Fn::Join': [
+                  '',
+                  [
+                    "Action=Publish&Message=$util.urlEncode($input.body)&TopicArn=$util.urlEncode('",
+                    {
+                      'Fn::Sub': [
+                        'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
+                        { topicName: 'myTopic' }
+                      ]
+                    },
+                    "')"
+                  ]
+                ]
+              },
+              'application/x-www-form-urlencoded': {
+                'Fn::Join': [
+                  '',
+                  [
+                    "Action=Publish&Message=$util.urlEncode($input.body)&TopicArn=$util.urlEncode('",
+                    {
+                      'Fn::Sub': [
+                        'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
+                        { topicName: 'myTopic' }
+                      ]
+                    },
+                    "')"
+                  ]
+                ]
+              }
+            },
+            IntegrationResponses: [
+              {
+                StatusCode: 200,
+                SelectionPattern: 200,
+                ResponseParameters: {},
+                ResponseTemplates: {}
+              },
+              {
+                StatusCode: 400,
+                SelectionPattern: 400,
+                ResponseParameters: {},
+                ResponseTemplates: {}
+              },
+              {
+                StatusCode: 500,
+                SelectionPattern: 500,
+                ResponseParameters: {},
+                ResponseTemplates: {}
+              }
+            ]
+          },
+          MethodResponses: [
+            {
+              ResponseParameters: {},
+              ResponseModels: {},
+              StatusCode: 200
+            },
+            {
+              ResponseParameters: {},
+              ResponseModels: {},
+              StatusCode: 400
+            },
+            {
+              ResponseParameters: {},
+              ResponseModels: {},
+              StatusCode: 500
+            }
+          ]
+        }
+      }
+    })
+  })
+
   it('should return the default template for application/json when one is not given', () => {
     const httpWithoutRequestTemplate = {
       path: 'foo/bar1',

--- a/lib/package/sqs/compileMethodsToSqs.test.js
+++ b/lib/package/sqs/compileMethodsToSqs.test.js
@@ -221,6 +221,105 @@ describe('#compileMethodsToSqs()', () => {
     })
   })
 
+  it('should create corresponding resources when sqs proxies are given with private', () => {
+    serverlessApigatewayServiceProxy.validated = {
+      events: [
+        {
+          serviceName: 'sqs',
+          http: {
+            queueName: 'myQueue',
+            path: 'sqs',
+            method: 'post',
+            auth: {
+              authorizationType: 'NONE'
+            },
+            private: true
+          }
+        }
+      ]
+    }
+    serverlessApigatewayServiceProxy.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi'
+    serverlessApigatewayServiceProxy.apiGatewayResources = {
+      sqs: {
+        name: 'sqs',
+        resourceLogicalId: 'ApiGatewayResourceSqs'
+      }
+    }
+
+    serverlessApigatewayServiceProxy.compileMethodsToSqs()
+
+    expect(serverless.service.provider.compiledCloudFormationTemplate.Resources).to.deep.equal({
+      ApiGatewayMethodsqsPost: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'POST',
+          RequestParameters: {},
+          AuthorizationType: 'NONE',
+          AuthorizationScopes: undefined,
+          AuthorizerId: undefined,
+          ApiKeyRequired: true,
+          ResourceId: { Ref: 'ApiGatewayResourceSqs' },
+          RestApiId: { Ref: 'ApiGatewayRestApi' },
+          Integration: {
+            IntegrationHttpMethod: 'POST',
+            Type: 'AWS',
+            Credentials: { 'Fn::GetAtt': ['ApigatewayToSqsRole', 'Arn'] },
+            Uri: {
+              'Fn::Sub': [
+                'arn:aws:apigateway:${AWS::Region}:sqs:path//${AWS::AccountId}/${queueName}',
+                {
+                  queueName: 'myQueue'
+                }
+              ]
+            },
+            RequestParameters: {
+              'integration.request.querystring.Action': "'SendMessage'",
+              'integration.request.querystring.MessageBody': 'method.request.body'
+            },
+            RequestTemplates: { 'application/json': '{statusCode:200}' },
+            IntegrationResponses: [
+              {
+                StatusCode: 200,
+                SelectionPattern: 200,
+                ResponseParameters: {},
+                ResponseTemplates: {}
+              },
+              {
+                StatusCode: 400,
+                SelectionPattern: 400,
+                ResponseParameters: {},
+                ResponseTemplates: {}
+              },
+              {
+                StatusCode: 500,
+                SelectionPattern: 500,
+                ResponseParameters: {},
+                ResponseTemplates: {}
+              }
+            ]
+          },
+          MethodResponses: [
+            {
+              ResponseParameters: {},
+              ResponseModels: {},
+              StatusCode: 200
+            },
+            {
+              ResponseParameters: {},
+              ResponseModels: {},
+              StatusCode: 400
+            },
+            {
+              ResponseParameters: {},
+              ResponseModels: {},
+              StatusCode: 500
+            }
+          ]
+        }
+      }
+    })
+  })
+
   it('should not create corresponding resources when other proxies are given', () => {
     serverlessApigatewayServiceProxy.validated = {
       events: [


### PR DESCRIPTION
Currently, Serverless allows API Key validation by using a field called private. This plugin also does but it doesn't allow it to pass the validation with this error:
```
child "sqs" fails because ["private" is not allowed]
```
This PR just to allow private field to pass the validation.